### PR TITLE
huggingface login for projects must login while running

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ pydantic==1.10.11
 fastapi==0.95.1
 sse-starlette
 matplotlib
+huggingface_hub

--- a/src/llmtuner/hparams/model_args.py
+++ b/src/llmtuner/hparams/model_args.py
@@ -1,6 +1,7 @@
 import torch
 from typing import Literal, Optional
 from dataclasses import dataclass, field
+from huggingface_hub.hf_api import HfFolder
 
 
 @dataclass
@@ -63,6 +64,11 @@ class ModelArguments:
         default=False,
         metadata={"help": "Whether to plot the training loss after fine-tuning or not."}
     )
+    hf_hub_token  : Optional[str] = field(
+        default=None,
+        metadata={"help": "Path to the directory containing the checkpoints of the reward model."}
+    )
+
 
     def __post_init__(self):
         if self.checkpoint_dir is not None: # support merging multiple lora weights
@@ -70,3 +76,6 @@ class ModelArguments:
 
         if self.quantization_bit is not None:
             assert self.quantization_bit in [4, 8], "We only accept 4-bit or 8-bit quantization."
+
+        if self.use_auth_token == True and self.hf_hub_token != None:
+            HfFolder.save_token(self.hf_hub_token)


### PR DESCRIPTION
hi， 超级感谢提供了这个project。最近见到的写得最好看的代码没有之一。


关于这个pull request：
我们的平台提供的GPU是在Flyte上运行，需要本地build docker，开始运行之后不能够再进行任何交互。
所以添加了这段代码，如果输入参数中加入  `--hf_hub_token hf_*******`，就可以再代码运行的过程中加入hugging face 的access token，如果不在参数中加入，则对原来的逻辑没有影响。