### PR TITLE
Fix: Change rouge-chinese package name to rouge_chinese

### DIFF
--- a/src/llmtuner/extras/packages.py
+++ b/src/llmtuner/extras/packages.py
@@ -18,7 +18,7 @@ _flash_attn2_available = is_package_available("flash_attn") and get_package_vers
 _jieba_available = is_package_available("jieba")
 _matplotlib_available = is_package_available("matplotlib")
 _nltk_available = is_package_available("nltk")
-_rouge_available = is_package_available("rouge-chinese")
+_rouge_available = is_package_available("rouge_chinese")
 _starlette_available = is_package_available("sse-starlette")
 _uvicorn_available = is_package_available("uvicorn")
 


### PR DESCRIPTION
To reproduce:
python:
importlib.util.find_spec('rouge-chinese') -> None
importlib.util.find_spec('rouge_chinese') -> ModuleSpec(name='rouge_chinese'...) from rouge_chinese import Rouge
print(Rouge.__module__) -> rouge_chinese