### PR TITLE
Improve get_current_device

### DIFF
--- a/src/llmtuner/extras/misc.py
+++ b/src/llmtuner/extras/misc.py
@@ -69,11 +69,11 @@ def count_parameters(model: torch.nn.Module) -> Tuple[int, int]:
 
 def get_current_device() -> str:
     import accelerate
-    dummy_accelerator = accelerate.Accelerator()
+    local_rank = int(os.environ.get('LOCAL_RANK', '0'))
     if accelerate.utils.is_xpu_available():
-        return "xpu:{}".format(dummy_accelerator.local_process_index)
+        return "xpu:{}".format(local_rank)
     else:
-        return dummy_accelerator.local_process_index if torch.cuda.is_available() else "cpu"
+        return local_rank if torch.cuda.is_available() else "cpu"
 
 
 def get_logits_processor() -> "LogitsProcessorList":


### PR DESCRIPTION
If using ```accelerate.Accelerator()```, it will cause the premature setting of the ```ACCELERATE_USE_DEEPSPEED ```environment variable, resulting in the regeneration of ```DeepSpeedPlugin``` and causing a change in the type of ```trainer.accelerator.state.deepspeed_plugin.hf_ds_config```
 [source code: regeneration DeepSpeedPlugin](https://github.com/huggingface/accelerate/blob/3499cf25aa431ed3eeb7969f1d9b501ef20d0911/src/accelerate/accelerator.py#L284-L292)
[source code: HfTrainerDeepSpeedConfig  -> HfDeepSpeedConfig ](https://github.com/huggingface/accelerate/blob/3499cf25aa431ed3eeb7969f1d9b501ef20d0911/src/accelerate/utils/dataclasses.py#L600)

which can lead to errors similar to https://github.com/microsoft/DeepSpeed/issues/3733, https://github.com/hiyouga/LLaMA-Factory/issues/286. Although rebuilding Seq2SeqTrainingArguments before Training can solve this issue, it may be better to use the LOCAL_RANK environment variable. 

Refer to qlora: https://github.com/artidoro/qlora/blob/main/qlora.py#L303