### PR TITLE
add empty template for fine-tuning completion model

### DIFF
--- a/src/llmtuner/data/template.py
+++ b/src/llmtuner/data/template.py
@@ -460,6 +460,21 @@ register_template(
 
 
 register_template(
+    name="empty",
+    prefix=[
+        "{{system}}"
+    ],
+    prompt=[
+        "{{query}}",
+    ],
+    system="",
+    sep=[
+        ""
+    ]
+)
+
+
+register_template(
     name="falcon",
     prefix=[
         "{{system}}"


### PR DESCRIPTION
Completion 模型，比如 [sqlcoder](https://github.com/defog-ai/sqlcoder/blob/main/inference.py)。
并没有固定的 Prompt 模版（有参考 Prompt）。

所以增加 Empty 模版，允许使用空白模版对模型进行微调，并使用 ChatCompletion 接口提供 Completion 的使用。

已经测试在 sqlcoder-7b 模型上微调和提供服务正常。