### PR TITLE
Update requirements.txt With einops dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ pydantic
 fastapi
 sse-starlette
 matplotlib
+einops


### PR DESCRIPTION
einops dependency is needed foe phi-2 finetuning.