### PR TITLE
fix ：TypeError in formatter.py when value is None

### DIFF
--- a/src/llmtuner/data/formatter.py
+++ b/src/llmtuner/data/formatter.py
@@ -95,6 +95,7 @@ class StringFormatter(Formatter):
         for slot in self.slots:
             if isinstance(slot, str):
                 for name, value in kwargs.items():
+                    value = value if value is not None else ""
                     slot = slot.replace("{{" + name + "}}", value, 1)
                 elements.append(slot)
             elif isinstance(slot, (dict, set)):


### PR DESCRIPTION
Title: Fix TypeError in formatter.py for Issue [#2282](https://github.com/hiyouga/LLaMA-Factory/issues/2282)

Content:


This PR addresses the TypeError encountered in formatter.py when 'value' is None as reported in Issue #2282.

Changes:

- Updated the Formatter.apply method to handle None values by replacing them with an empty string.

Here's the key change:

```python
for slot in self.slots:
    if isinstance(slot, str):
        for name, value in kwargs.items():
            value = value if value is not None else ""
            slot = slot.replace("{{" + name + "}}", value, 1)
        elements.append(slot)
```

This fix has been tested and no TypeError is thrown now.

Please review. Thanks!
