### PR TITLE
FEAT: add HF tags for models that have been trained with llama-factory

### DIFF
--- a/src/llmtuner/model/loader.py
+++ b/src/llmtuner/model/loader.py
@@ -87,6 +87,17 @@ def load_model_and_tokenizer(
             **config_kwargs,
         )
 
+        # Add llama-factory tag to push these tags on the Hub.
+        # the feature is available since 4.37.0 but adding the check
+        # just in case
+        if hasattr(model, "add_model_tags"):
+            model.add_model_tags(["llama-factory"])
+        else:
+            logger.warning_once(
+                "Was not able to properly tag the model, if you want to use the model tagging feature, make sure to "
+                "have transformers>=4.37.0 installed on your environment."
+            )
+
     patch_model(model, tokenizer, model_args, is_trainable)
     register_autoclass(config, model, tokenizer)
 


### PR DESCRIPTION
Hi @hiyouga ! 

Great work on the Llama-Factory library ! 🚀
I would like to propose a new feature request: *model tagging*

With transformers 4.37.0 we added model tagging support by automatically tagging models on the Hub. That way you could sort models that have a specific tag, e.g. it you want to filter models that have the tag `trl` you could use think link: https://huggingface.co/models?other=trl / so for llama-factory: https://huggingface.co/models?other=llama-factory

I see it is already done in the `get_modelcard_args` method but `add_model_tags` enables you to push that tag even if you don't call `trainer.push_to_hub` and simply calling `model.push_to_hub()` will automatically push the model + the `llama-factory` tag

Let me know if this PR makes sense, otherwise we can also close it as technically the tags are already pushed, this PR would just cover the case where users use your trainer without pushing the trainer itself but the model.