### PR TITLE
fix deepspeed ppo RuntimeError

### DIFF
--- a/src/llmtuner/model/loader.py
+++ b/src/llmtuner/model/loader.py
@@ -61,7 +61,7 @@ def load_model(
     """
     init_kwargs = _get_init_kwargs(model_args)
     config = AutoConfig.from_pretrained(model_args.model_name_or_path, **init_kwargs)
-    patch_config(config, tokenizer, model_args, init_kwargs, is_trainable)
+    patch_config(config, tokenizer, model_args,finetuning_args, init_kwargs, is_trainable)
 
     model = None
     if is_trainable and model_args.use_unsloth:

--- a/src/llmtuner/model/patcher.py
+++ b/src/llmtuner/model/patcher.py
@@ -264,6 +264,7 @@ def patch_config(
     config: "PretrainedConfig",
     tokenizer: "PreTrainedTokenizer",
     model_args: "ModelArguments",
+    finetuning_args: "FinetuningArguments",
     init_kwargs: Dict[str, Any],
     is_trainable: bool,
 ) -> None:
@@ -288,7 +289,8 @@ def patch_config(
     if not is_deepspeed_zero3_enabled():
         init_kwargs["low_cpu_mem_usage"] = model_args.low_cpu_mem_usage
         if "device_map" not in init_kwargs:  # quant models cannot use auto device map
-            init_kwargs["device_map"] = model_args.device_map or {"": get_current_device()}
+            if finetuning_args.stage not in ["ppo"]: #ppo stage should not set device map
+                init_kwargs["device_map"] = model_args.device_map or {"": get_current_device()}
 
 
 def patch_model(

--- a/src/llmtuner/model/patcher.py
+++ b/src/llmtuner/model/patcher.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from transformers import PretrainedConfig, PreTrainedTokenizer
     from trl import AutoModelForCausalLMWithValueHead
 
-    from ..hparams import ModelArguments
+    from ..hparams import ModelArguments,FinetuningArguments
 
 
 logger = get_logger(__name__)


### PR DESCRIPTION
# What does this PR do?
 fix deepspeed ppo RuntimeError: Expected all tensors to be on the same device, but found at least two devices

Fixes bug  in my experiment

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?

when using deepspeed in ppo training,the model device map should not set，when the devce set 
   
![image](https://github.com/hiyouga/LLaMA-Factory/assets/30854283/72f99158-4cc9-4495-8cac-6aa5d1f82bbf)

it cause the runtime error problem 
![image](https://github.com/hiyouga/LLaMA-Factory/assets/30854283/027add3c-4117-4609-aaa9-48ab94fee49e)

but，when we not  set the device_map,it can work
![image](https://github.com/hiyouga/LLaMA-Factory/assets/30854283/e33f8ad0-ae67-4dd0-ae63-8eb706c0646b)

