### PR TITLE
修复了在 transformers > 4.36.2 版本中部分模型合并 Lora 模型时因生成配置校验而导致的崩溃问题

### DIFF
--- a/src/llmtuner/train/tuner.py
+++ b/src/llmtuner/train/tuner.py
@@ -66,7 +66,7 @@ def export_model(args: Optional[Dict[str, Any]] = None):
 
     # Configuration check and fix
     config = model.generation_config
-    if config.do_sample and (
+    if config.do_sample == False and (
         (config.temperature is not None and config.temperature != 1.0) or
         (config.top_p is not None and config.top_p != 1.0) or
         (config.typical_p is not None and config.typical_p != 1.0)

--- a/src/llmtuner/train/tuner.py
+++ b/src/llmtuner/train/tuner.py
@@ -71,7 +71,7 @@ def export_model(args: Optional[Dict[str, Any]] = None):
         (config.top_p is not None and config.top_p != 1.0) or
         (config.typical_p is not None and config.typical_p != 1.0)
     ):
-        config.do_sample = False
+        config.do_sample = True
 
     model.save_pretrained(
         save_directory=model_args.export_dir,

--- a/src/llmtuner/train/tuner.py
+++ b/src/llmtuner/train/tuner.py
@@ -66,7 +66,7 @@ def export_model(args: Optional[Dict[str, Any]] = None):
 
     # Configuration check and fix
     config = model.generation_config
-    if config.do_sample == False and (
+    if not config.do_sample and (
         (config.temperature is not None and config.temperature != 1.0) or
         (config.top_p is not None and config.top_p != 1.0) or
         (config.typical_p is not None and config.typical_p != 1.0)

--- a/src/llmtuner/train/tuner.py
+++ b/src/llmtuner/train/tuner.py
@@ -64,6 +64,15 @@ def export_model(args: Optional[Dict[str, Any]] = None):
         for param in model.parameters():
             param.data = param.data.to(output_dtype)
 
+    # Configuration check and fix
+    config = model.generation_config
+    if config.do_sample and (
+        (config.temperature is not None and config.temperature != 1.0) or
+        (config.top_p is not None and config.top_p != 1.0) or
+        (config.typical_p is not None and config.typical_p != 1.0)
+    ):
+        config.do_sample = False
+
     model.save_pretrained(
         save_directory=model_args.export_dir,
         max_shard_size="{}GB".format(model_args.export_size),


### PR DESCRIPTION
# What does this PR do?

Fixes #2943 

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?

已知默认生成配置会导致保存问题的模型:
 - Llama2
 - chinese-alpaca-2