### PR TITLE
Tool call history

### DIFF
--- a/src/llmtuner/api/protocol.py
+++ b/src/llmtuner/api/protocol.py
@@ -48,6 +48,7 @@ class FunctionCall(BaseModel):
 class ChatMessage(BaseModel):
     role: Role
     content: str
+    tool_calls: Optional[List[FunctionCall]] = None
 
 
 class ChatCompletionMessage(BaseModel):

--- a/src/llmtuner/data/formatter.py
+++ b/src/llmtuner/data/formatter.py
@@ -54,7 +54,7 @@ def default_tool_formatter(tools: List[Dict[str, Any]]) -> str:
 
 
 def default_tool_extractor(content: str) -> Union[str, Tuple[str, str]]:
-    regex = re.compile(r"Action:\s*([a-zA-Z0-9_]+).*?Action Input:\s*(.*)", re.DOTALL)
+    regex = re.compile(r"Action:\s*([a-zA-Z0-9_-]+).*?Action Input:\s*(.*)", re.DOTALL)
     action_match = re.search(regex, content)
     if not action_match:
         return content


### PR DESCRIPTION
# What does this PR do?
This PR includes tool calls in the message history, rather than just tool observations. The tool call content is included in the message content, extracted from the tool_calls field.

Additionally, the regex for the defualt_tool_extractor is modified to accept function names containing a hyphen "-"

Fixes # (issue)

This seems to provide better results for long conversations using multiple tool calls.

The hyphen is used in tool calls from C# Microsoft semantic kernel. This change to the regex makes the API compatible with semantic kernel.

## Before submitting

- [✓] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
