### PR TITLE
Fix pile dataset download config

### DIFF
--- a/data/dataset_info.json
+++ b/data/dataset_info.json
@@ -364,12 +364,11 @@
     }
   },
   "pile": {
-    "hf_hub_url": "EleutherAI/pile",
+    "hf_hub_url": "monology/pile-uncopyrighted",
     "ms_hub_url": "AI-ModelScope/pile",
     "columns": {
       "prompt": "text"
-    },
-    "subset": "all"
+    }
   },
   "skypile": {
     "hf_hub_url": "Skywork/SkyPile-150B",


### PR DESCRIPTION
# What does this PR do?

Fixes # (issue)

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?

Refer to the Pile dataset [discussion](https://huggingface.co/datasets/EleutherAI/pile/discussions/15).
The Pile dataset originally hosted on Hugging Face is no longer downloadable. 
To address this issue, the original dataset configuration has been switched to an [alternative dataset](https://huggingface.co/datasets/monology/pile-uncopyrighted). 
Now, the Pile dataset can be downloaded normally.