### PR TITLE
add support qwen1.5-based DPO for Flash Attention 2 

### DIFF
--- a/src/llmtuner/train/dpo/workflow.py
+++ b/src/llmtuner/train/dpo/workflow.py
@@ -28,6 +28,9 @@ def run_dpo(
     dataset = get_dataset(tokenizer, model_args, data_args, training_args, stage="rm")
     model = load_model(tokenizer, model_args, finetuning_args, training_args.do_train)
 
+    if model_args.flash_attn and 'Qwen2' in model.__class__.__name__:
+        tokenizer.padding_side = 'left'
+
     data_collator = PairwiseDataCollatorWithPadding(
         tokenizer=tokenizer,
         pad_to_multiple_of=8,


### PR DESCRIPTION
# What does this PR do?

Fixes bug:  when use qwen1.5 models and Flash Attention 2  on stage DPO,   the defalut padding_side of the qwen1.5 tokenizer is 'right'. However , as [qwen1.5](https://github.com/huggingface/transformers/blob/main/src/transformers/models/qwen2/modeling_qwen2.py#L1004) define,  `tokenizer.padding_side  = 'left'` should be call before tokenizing the input , otherwise unexpected behaviour may happened and it will raise a ValueError.

```shell
192.168.1.38:   File "/usr/local/lib/python3.10/dist-packages/transformers/models/qwen2/modeling_qwen2.py", line 1173, in forward
192.168.1.38:     outputs = self.model(
192.168.1.38:   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1502, in _wrapped_call_impl
192.168.1.38:     return self._call_impl(*args, **kwargs)
192.168.1.38:   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1548, in _call_impl
192.168.1.38:     result = forward_call(*args, **kwargs)
192.168.1.38:   File "/usr/local/lib/python3.10/dist-packages/transformers/models/qwen2/modeling_qwen2.py", line 1008, in forward
192.168.1.38:     raise ValueError(
192.168.1.38: ValueError: You are attempting to perform batched generation with padding_side='right' this may lead to unexpected behaviour for Flash Attention version of Qwen2. Make sure to  call `tokenizer.padding_side  = 'left'` before tokenizing the input.

```


## Before submitting

- [✔] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
