### PR TITLE
Update dataset the-stack-v2

### DIFF
--- a/data/dataset_info.json
+++ b/data/dataset_info.json
@@ -378,7 +378,7 @@
     }
   },
   "the_stack": {
-    "hf_hub_url": "bigcode/the-stack",
+    "hf_hub_url": "bigcode/the-stack-v2",
     "ms_hub_url": "AI-ModelScope/the-stack",
     "columns": {
       "prompt": "content"


### PR DESCRIPTION
This just update [bigcode/the-stack](https://huggingface.co/datasets/bigcode/the-stack) to [bigcode/the-stack-v2](https://huggingface.co/datasets/bigcode/the-stack-v2), `67.5`TB for all programming languages.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
