### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ fastapi
 sse-starlette
 matplotlib
 fire
+bitsandbytes


### PR DESCRIPTION
fix:  No module named “bitsandbytes’,  error: Traceback (most recent call last): File "transformers/trainer.py", line 1178, in
get_optimizer_cls_and_ kwargs
from bitsandbytes.opt im import Adamw, Lion, RMSprop


- [ ] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
