### PR TITLE
Add model name for api_demo

### DIFF
--- a/examples/inference/api_demo.sh
+++ b/examples/inference/api_demo.sh
@@ -3,5 +3,6 @@
 CUDA_VISIBLE_DEVICES=0 API_PORT=8000 python ../../src/api_demo.py \
     --model_name_or_path meta-llama/Llama-2-7b-hf \
     --adapter_name_or_path ../../saves/LLaMA2-7B/lora/sft \
+    --model_revision Llama-2-7b \
     --template default \
     --finetuning_type lora

--- a/src/llmtuner/api/app.py
+++ b/src/llmtuner/api/app.py
@@ -82,7 +82,11 @@ def create_app(chat_model: "ChatModel") -> "FastAPI":
 
     @app.get("/v1/models", response_model=ModelList)
     async def list_models():
-        model_card = ModelCard(id="gpt-3.5-turbo")
+        if chat_model.models_args.model_revision != "main":  # the default of model_revision is main
+            ids = chat_model.models_args.model_revision
+        else:
+            ids = "gpt-3.5-turbo"
+        model_card = ModelCard(id=ids)
         return ModelList(data=[model_card])
 
     @app.post("/v1/chat/completions", response_model=ChatCompletionResponse, status_code=status.HTTP_200_OK)

--- a/src/llmtuner/chat/chat_model.py
+++ b/src/llmtuner/chat/chat_model.py
@@ -28,6 +28,7 @@ class ChatModel:
         else:
             raise NotImplementedError("Unknown backend: {}".format(model_args.infer_backend))
 
+        self.models_args = model_args
         self._loop = asyncio.new_event_loop()
         self._thread = Thread(target=_start_background_loop, args=(self._loop,), daemon=True)
         self._thread.start()


### PR DESCRIPTION
Add the function to specify the model name of the api_demo.

# What does this PR do?

This PR could add the function to specify the model name of the api_demo.
The original code only assigns the "gpt-3.5-turbo" in ModelCard and cannot make a custom name for the loaded model.

Therefore, I use the `model_revision` parameter to give the name of the loaded model. It only gets the reference of `models_args` from the init of ChatModel and does not change other worklines.

I think the introduction of models_args will be convenient for use during the api_demo in the future.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
