### PR TITLE
fix: splitted Dockerfile's CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ RUN pip install -e .[deepspeed,metrics,bitsandbytes,qwen]
 VOLUME [ "/root/.cache/huggingface/", "/app/data", "/app/output" ]
 EXPOSE 7860
 
-CMD [ "llamafactory-cli webui" ]
+CMD [ "llamafactory-cli", "webui" ]


### PR DESCRIPTION
# What does this PR do?
Fixed Dockerfile's CMD.
When I build a docker image using current CMD and run, below error occurs.
~~~
/opt/nvidia/nvidia_entrypoint.sh: line 49: /usr/local/bin/llamafactory-cli webui: No such file or directory
~~~
So, I splitted CMD in Dockerfile, and it worked well.

Fixes #3603 

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
