### PR TITLE
Remove Redundant Environment Variable Usage

### DIFF
--- a/src/llmtuner/webui/interface.py
+++ b/src/llmtuner/webui/interface.py
@@ -79,6 +79,4 @@ def run_web_ui() -> None:
 
 def run_web_demo() -> None:
     server_name = os.environ.get("GRADIO_SERVER_NAME", "0.0.0.0")
-    server_port = int(os.environ.get("GRADIO_SERVER_PORT", "7860"))
-    gradio_share = bool(int(os.environ.get("GRADIO_SHARE", "0")))
-    create_web_demo().queue().launch(share=gradio_share, server_name=server_name, server_port=server_port)
+    create_web_demo().queue().launch(server_name=server_name)

--- a/src/llmtuner/webui/interface.py
+++ b/src/llmtuner/webui/interface.py
@@ -72,9 +72,7 @@ def create_web_demo() -> gr.Blocks:
 
 def run_web_ui() -> None:
     server_name = os.environ.get("GRADIO_SERVER_NAME", "0.0.0.0")
-    server_port = int(os.environ.get("GRADIO_SERVER_PORT", "7860"))
-    gradio_share = bool(int(os.environ.get("GRADIO_SHARE", "0")))
-    create_ui().queue().launch(share=gradio_share, server_name=server_name, server_port=server_port)
+    create_ui().queue().launch(server_name=server_name)
 
 
 def run_web_demo() -> None:

--- a/src/webui.py
+++ b/src/webui.py
@@ -5,9 +5,7 @@ from llmtuner.webui.interface import create_ui
 
 def main():
     server_name = os.environ.get("GRADIO_SERVER_NAME", "0.0.0.0")
-    server_port = int(os.environ.get("GRADIO_SERVER_PORT", "7860"))
-    gradio_share = bool(int(os.environ.get("GRADIO_SHARE", "0")))
-    create_ui().queue().launch(share=gradio_share, server_name=server_name, server_port=server_port)
+    create_ui().queue().launch(server_name=server_name)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# What does this PR do?

Fixes #3653

With Gradio,

- the `GRADIO_SERVER_PORT` is by default 7860 
- the `GRADIO_SHARE` is by default None (0)

So we don't really need these environment variables. Additionally, the `GRADIO_SERVER_PORT` is causing issues when I already have another gradio app running on my machine since they use 7860 by default. (Gradio documentation about these variables here: https://www.gradio.app/docs/gradio/interface#interface-launch-arguments)

By removing these manual presets and let Gradio handle the default values, the app works exactly the same but allows for more flexibility (automatically using next available port, such as 7861, when 7860 is already occupied by another app)

## Before submitting

- [O] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?

