### PR TITLE
support gradio root_path

### DIFF
--- a/src/llmtuner/webui/interface.py
+++ b/src/llmtuner/webui/interface.py
@@ -73,7 +73,8 @@ def create_web_demo() -> gr.Blocks:
 def run_web_ui() -> None:
     gradio_share = os.environ.get("GRADIO_SHARE", "0").lower() in ["true", "1"]
     server_name = os.environ.get("GRADIO_SERVER_NAME", "0.0.0.0")
-    create_ui().queue().launch(share=gradio_share, server_name=server_name)
+    root_path = os.environ.get("GRADIO_ROOT_PATH", "/")
+    create_ui().queue().launch(share=gradio_share, server_name=server_name, root_path=root_path)
 
 
 def run_web_demo() -> None:


### PR DESCRIPTION
# What does this PR do?

支持gradio的root_path设置，可以将llama-factory的webui部署在子路径，如"/llama-factory" (通过"GRADIO_ROOT_PATH"环境变量设置)