### PR TITLE
feat: pass the `max_lora_rank` parameter to vLLM backend

### DIFF
--- a/src/llamafactory/chat/vllm_engine.py
+++ b/src/llamafactory/chat/vllm_engine.py
@@ -59,6 +59,7 @@ class VllmEngine(BaseEngine):
             "disable_log_requests": True,
             "enforce_eager": model_args.vllm_enforce_eager,
             "enable_lora": model_args.adapter_name_or_path is not None,
+            "max_lora_rank": model_args.vllm_max_lora_rank,
         }
 
         if model_args.visual_inputs:

--- a/src/llamafactory/hparams/model_args.py
+++ b/src/llamafactory/hparams/model_args.py
@@ -117,7 +117,10 @@ class ModelArguments:
         default=False,
         metadata={"help": "Whether or not to disable CUDA graph in the vLLM engine."},
     )
-    vllm_max_lora_rank: int = field(default=8, metadata={"help": "The maximum supported rank of all LoRAs."})
+    vllm_max_lora_rank: int = field(
+        default=8,
+        metadata={"help": "Maximum rank of all LoRAs in the vLLM engine."},
+    )
     offload_folder: str = field(
         default="offload",
         metadata={"help": "Path to offload model weights."},

--- a/src/llamafactory/hparams/model_args.py
+++ b/src/llamafactory/hparams/model_args.py
@@ -117,6 +117,7 @@ class ModelArguments:
         default=False,
         metadata={"help": "Whether or not to disable CUDA graph in the vLLM engine."},
     )
+    vllm_max_lora_rank: int = field(default=8, metadata={"help": "The maximum supported rank of all LoRAs."})
     offload_folder: str = field(
         default="offload",
         metadata={"help": "Path to offload model weights."},


### PR DESCRIPTION
# What does this PR do?

If the user train the llm with lora with lora rank greater than 16, the vLLM backend will fail to process with the error: `ValueError: LoRA rank XXX is greater than max_lora_rank 16`. This commit pass the `max_lora_rank` parameter to vLLM backend to support a higher lora rank (currently up to 64 due to the vLLM constraints).
