### PR TITLE
Add openchat-3.6-8B support

### DIFF
--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -756,6 +756,23 @@ _register_template(
     force_system=True,
 )
 
+_register_template(
+    name="openchat-3.6",
+    format_user=StringFormatter(
+        slots=[
+            (
+                "<|start_header_id|>GPT4 Correct User<|end_header_id|>\n\n{{content}}<|eot_id|>"
+                "<|start_header_id|>GPT4 Correct Assistant<|end_header_id|>\n\n"
+            )
+        ]
+    ),
+    format_system=StringFormatter(
+        slots=[{"bos_token"}, "<|start_header_id|>System<|end_header_id|>\n\n{{content}}<|eot_id|>"]
+    ),
+    stop_words=["<|eot_id|>"],
+    replace_eos=True,
+)
+
 
 _register_template(
     name="orion",

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -761,7 +761,7 @@ _register_template(
     format_user=StringFormatter(
         slots=[
             (
-                "<|start_header_id|>GPT4 Correct User<|end_header_id|>\n\n{{content}}<|eot_id|>",
+                "<|start_header_id|>GPT4 Correct User<|end_header_id|>\n\n{{content}}<|eot_id|>"
                 "<|start_header_id|>GPT4 Correct Assistant<|end_header_id|>\n\n"
             )
         ]

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -761,16 +761,15 @@ _register_template(
     format_user=StringFormatter(
         slots=[
             (
-                "<|start_header_id|>GPT4 Correct User<|end_header_id|>\n\n{{content}}<|eot_id|>"
+                "<|start_header_id|>GPT4 Correct User<|end_header_id|>\n\n{{content}}<|eot_id|>",
                 "<|start_header_id|>GPT4 Correct Assistant<|end_header_id|>\n\n"
             )
         ]
     ),
-    format_system=StringFormatter(
-        slots=[{"bos_token"}, "<|start_header_id|>System<|end_header_id|>\n\n{{content}}<|eot_id|>"]
-    ),
+    format_system=StringFormatter(slots=[{"bos_token"}, "{{content}}"]),
     stop_words=["<|eot_id|>"],
     replace_eos=True,
+    force_system=True,
 )
 
 

--- a/src/llamafactory/extras/constants.py
+++ b/src/llamafactory/extras/constants.py
@@ -706,6 +706,15 @@ register_model_group(
     template="openchat",
 )
 
+register_model_group(
+    models={
+        "OpenChat3.6-8B-Chat": {
+            DownloadSource.DEFAULT: "openchat/openchat-3.6-8b-20240522",
+        }
+    },
+    template="openchat-3.6",
+)
+
 
 register_model_group(
     models={


### PR DESCRIPTION
# What does this PR do?

Add OpenChat-3.6-8B template `openchat-3.6` and  Model Group `OpenChat3.6-8B-Chat`.
[OpenChat-3.6-8B](https://huggingface.co/openchat/openchat-3.6-8b-20240522) is a new model from OpenChat team. The original `openchat` template is outdated for this model.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
