### PR TITLE
Set scheduler_specific_kwargs to get_scheduler

### DIFF
--- a/src/llamafactory/train/utils.py
+++ b/src/llamafactory/train/utils.py
@@ -379,6 +379,7 @@ def create_custom_scheduler(
                 optimizer=optimizer_dict[param],
                 num_warmup_steps=training_args.get_warmup_steps(num_training_steps),
                 num_training_steps=num_training_steps,
+                scheduler_specific_kwargs=training_args.lr_scheduler_kwargs,
             )
 
         def scheduler_hook(param: "torch.nn.Parameter"):


### PR DESCRIPTION
# What does this PR do?

When setting the argument `--lr_scheduler_type cosine_with_min_lr` for `python src/train.py`, the following error occurs:

```
ValueError: One of min_lr or min_lr_rate should be set through the `lr_scheduler_kwargs`
```

In response, I provided the argument `--lr_scheduler_kwargs '{"min_lr": 1e-7}'`, but an error still occurs because the `scheduler_specific_kwargs` argument is not properly passed to the `get_scheduler` function within the `create_custom_scheduler` function in `src/llamafactory/train/utils.py`.

To resolve this error, I have modified the code to set the `scheduler_specific_kwargs` argument to `training_args.lr_scheduler_kwargs` within the `create_custom_scheduler` function.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
