### PR TITLE
fix unexpected keyword argument 'prompt'

### DIFF
--- a/src/llamafactory/chat/vllm_engine.py
+++ b/src/llamafactory/chat/vllm_engine.py
@@ -158,13 +158,16 @@ class VllmEngine(BaseEngine):
         )
 
         result_generator = self.model.generate(
-            prompt=None,
+            #prompt=None,
             sampling_params=sampling_params,
             request_id=request_id,
-            prompt_token_ids=prompt_ids,
+            # 修改关键内容为下行,原始参数均已注释
+            inputs = messages[-1]['content'],
+            #prompt_token_ids=prompt_ids,
             lora_request=self.lora_request,
-            multi_modal_data=multi_modal_data,
+            #multi_modal_data=multi_modal_data,
         )
+
         return result_generator
 
     async def start(self) -> None:


### PR DESCRIPTION
# What does this PR do?

Fixes # (issue)
Loading a model with vllm under vllm version 0.4.3 using vllm through this project results in an error `unexpected keyword argument 'prompt'`.

Modified vllm_engine.py to make the chat function work temporarily, looking forward to the author's professional fix

## Before submitting

- [ √] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
