### PR TITLE
fix bug when Model name is None, AttributeError: 'NoneType' object ha…

### DIFF
--- a/src/llamafactory/webui/common.py
+++ b/src/llamafactory/webui/common.py
@@ -40,6 +40,7 @@ def get_save_dir(*paths: str) -> os.PathLike:
     r"""
     Gets the path to saved model checkpoints.
     """
+    paths = (path for path in paths if path)
     paths = (path.replace(os.path.sep, "").replace(" ", "").strip() for path in paths)
     return os.path.join(DEFAULT_SAVE_DIR, *paths)
 


### PR DESCRIPTION
fix bug when Model name is None, AttributeError: 'NoneType' object has no attribute 'replace'

# What does this PR do?

Fix bug. 

The first startup using `python src/ webue.py`, The following error occurred:
`AttributeError: 'NoneType' object has no attribute 'replace' is reported because Model Name is None`

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
