### PR TITLE
Add npu option for model exporting

### DIFF
--- a/src/llamafactory/hparams/model_args.py
+++ b/src/llamafactory/hparams/model_args.py
@@ -145,9 +145,9 @@ class ModelArguments:
         default=1,
         metadata={"help": "The file shard size (in GB) of the exported model."},
     )
-    export_device: Literal["cpu", "cuda"] = field(
+    export_device: Literal["cpu", "cuda", "npu"] = field(
         default="cpu",
-        metadata={"help": "The device used in model export, use cuda to avoid addmm errors."},
+        metadata={"help": "The device used in model export, use cuda to avoid addmm errors; use npu/cuda to speed up exporting."},
     )
     export_quantization_bit: Optional[int] = field(
         default=None,

--- a/src/llamafactory/hparams/model_args.py
+++ b/src/llamafactory/hparams/model_args.py
@@ -145,9 +145,9 @@ class ModelArguments:
         default=1,
         metadata={"help": "The file shard size (in GB) of the exported model."},
     )
-    export_device: Literal["cpu", "cuda", "npu"] = field(
+    export_device: Literal["cpu", "auto"] = field(
         default="cpu",
-        metadata={"help": "The device used in model export, use cuda to avoid addmm errors; use npu/cuda to speed up exporting."},
+        metadata={"help": "The device used in model export, use `auto` to accelerate exporting."},
     )
     export_quantization_bit: Optional[int] = field(
         default=None,

--- a/src/llamafactory/webui/components/export.py
+++ b/src/llamafactory/webui/components/export.py
@@ -89,7 +89,7 @@ def create_export_tab(engine: "Engine") -> Dict[str, "Component"]:
         export_size = gr.Slider(minimum=1, maximum=100, value=1, step=1)
         export_quantization_bit = gr.Dropdown(choices=["none"] + GPTQ_BITS, value="none")
         export_quantization_dataset = gr.Textbox(value="data/c4_demo.json")
-        export_device = gr.Radio(choices=["cpu", "cuda"], value="cpu")
+        export_device = gr.Radio(choices=["cpu", "cuda", "npu"], value="cpu")
         export_legacy_format = gr.Checkbox()
 
     with gr.Row():

--- a/src/llamafactory/webui/components/export.py
+++ b/src/llamafactory/webui/components/export.py
@@ -89,7 +89,7 @@ def create_export_tab(engine: "Engine") -> Dict[str, "Component"]:
         export_size = gr.Slider(minimum=1, maximum=100, value=1, step=1)
         export_quantization_bit = gr.Dropdown(choices=["none"] + GPTQ_BITS, value="none")
         export_quantization_dataset = gr.Textbox(value="data/c4_demo.json")
-        export_device = gr.Radio(choices=["cpu", "cuda", "npu"], value="cpu")
+        export_device = gr.Radio(choices=["cpu", "cuda/npu"], value="cpu")
         export_legacy_format = gr.Checkbox()
 
     with gr.Row():

--- a/src/llamafactory/webui/components/export.py
+++ b/src/llamafactory/webui/components/export.py
@@ -89,7 +89,7 @@ def create_export_tab(engine: "Engine") -> Dict[str, "Component"]:
         export_size = gr.Slider(minimum=1, maximum=100, value=1, step=1)
         export_quantization_bit = gr.Dropdown(choices=["none"] + GPTQ_BITS, value="none")
         export_quantization_dataset = gr.Textbox(value="data/c4_demo.json")
-        export_device = gr.Radio(choices=["cpu", "cuda/npu"], value="cpu")
+        export_device = gr.Radio(choices=["cpu", "auto"], value="cpu")
         export_legacy_format = gr.Checkbox()
 
     with gr.Row():


### PR DESCRIPTION
# What does this PR do?

Add npu option for model exporting

## More Info
### 耗时测试
经测试，导出 qwen1.5-7b 模型 npu 和 cpu 的耗时如下（使用time统计的整个脚本执行时间）：
|   device   |   耗时   |
| ---- | ---- |
|   cpu   |   2m30.411s   |
|   npu   |   1m34.301s   |

### 启动脚本
```
ASCEND_RT_VISIBLE_DEVICES=0 llamafactory-cli export --model_name_or_path qwen/Qwen1.5-7B \
                --adapter_name_or_path saves/Qwen1.5-7B/lora/sft \
                --template qwen \
                --finetuning_type lora \
                --export_dir models/qwen1_5-7b_lora_sft \
                --export_size 2 \
                --export_device npu \
                --export_legacy_format false
```

### webui 变化
增加 npu 选项后，LlamaBoard 前端显示如图：

![image](https://github.com/hiyouga/LLaMA-Factory/assets/52243582/b574437b-9c95-40f8-810b-8f656aa91bf9)

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
