### PR TITLE
Fix #4077

### DIFF
--- a/src/llamafactory/cli.py
+++ b/src/llamafactory/cli.py
@@ -70,7 +70,11 @@ def main():
     elif command == Command.EXPORT:
         export_model()
     elif command == Command.TRAIN:
-        if get_device_count() > 1:
+        if get_device_count() > 0:
+            # NOTE (MengqingCao): why use torchrun when only one accelerator is available?
+            # DeepSpeed only warp model with DeepSpeedEngine when launching by distributed launcher,
+            # e.g., torchrun, causing some feature missing
+            # sa: https://github.com/huggingface/transformers/issues/24309
             master_addr = os.environ.get("MASTER_ADDR", "127.0.0.1")
             master_port = os.environ.get("MASTER_PORT", str(random.randint(20001, 29999)))
             logger.info("Initializing distributed tasks at: {}:{}".format(master_addr, master_port))

--- a/src/llamafactory/cli.py
+++ b/src/llamafactory/cli.py
@@ -71,10 +71,6 @@ def main():
         export_model()
     elif command == Command.TRAIN:
         if get_device_count() > 0:
-            # NOTE (MengqingCao): why use torchrun when only one accelerator is available?
-            # DeepSpeed only warp model with DeepSpeedEngine when launching by distributed launcher,
-            # e.g., torchrun, causing some feature missing
-            # sa: https://github.com/huggingface/transformers/issues/24309
             master_addr = os.environ.get("MASTER_ADDR", "127.0.0.1")
             master_port = os.environ.get("MASTER_PORT", str(random.randint(20001, 29999)))
             logger.info("Initializing distributed tasks at: {}:{}".format(master_addr, master_port))


### PR DESCRIPTION
# What does this PR do?

Fixes #4077

## More Info

经过复现，单卡使用 `llamafactory-cli train` 及 deepspeed 进行训练时会出现很多模型缺少 `save_checkpoint` 方法的 bug
![image](https://github.com/hiyouga/LLaMA-Factory/assets/52243582/0eb6c6e6-381c-4cca-b5e9-3b8eb546ca46)

deepspeed 只对分布式 launcher 启动的程序中的模型用 DeepSpeedEngine 包装，包装后才有 `save_checkpoint` 等方法。因此单卡程序也通过 torchrun 启动来避免此问题

**Related Issue**: https://github.com/huggingface/transformers/issues/24309

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
