### PR TITLE
Add MANIFEST.in so requirements.txt is present in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE requirements.txt


### PR DESCRIPTION
# What does this PR do?
Ensures that requirements.txt and the LICENSE file are correctly included in the source distribution (sdist) when the package is built (and eg; published to pypi).

Without this, we cannot build a conda package because a wheel cannot be successfully built from the current sdist (requirements.txt file is referenced by setup.py but is missing in the sdist).

Tested that this change correctly includes the requirements.txt file in the sdist using the procedure in the linked issue.

Fixes #4190

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
