### PR TITLE
Support vllm==0.5.0

### DIFF
--- a/src/llamafactory/chat/vllm_engine.py
+++ b/src/llamafactory/chat/vllm_engine.py
@@ -13,7 +13,10 @@ from .base_engine import BaseEngine, Response
 if is_vllm_available():
     from vllm import AsyncEngineArgs, AsyncLLMEngine, RequestOutput, SamplingParams
     from vllm.lora.request import LoRARequest
-    from vllm.sequence import MultiModalData
+    try:
+        from vllm.multimodal import MultiModalData  # vllm==0.5.0
+    except ImportError:
+        from vllm.sequence import MultiModalData  # vllm<0.5.0
 
 
 if TYPE_CHECKING:


### PR DESCRIPTION
# What does this PR do?

Fix #4238

vllm import changed today.
- https://github.com/vllm-project/vllm/blob/v0.5.0/vllm/sequence.py#L17C1-L18C1

before `from vllm.sequence import MultiModalData`
after `from vllm.multimodal import MultiModalData`

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
