### PR TITLE
add startup command in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
     ports:
       - "7860:7860"
       - "8000:8000"
+    command: ["llamafactory-cli", "webui"]
     ipc: host
     deploy:
       resources:


### PR DESCRIPTION
# What does this PR do?

add startup command in docker-compose.yml to avoid exiting the container and launch the LLaMA Board

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
