### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,3 +42,5 @@ EXPOSE 7860
 
 # Expose port 8000 for the API service
 EXPOSE 8000
+
+CMD [ "llamafactory-cli", "webui" ]


### PR DESCRIPTION
Adds the commands to correctly execute LLama-Factory servers

# What does this PR do?

Adds the Dockerfile commands in order to correctly execute LLama-Factory servers when container is started ("llamafactory-cli", "webui").

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
