### PR TITLE
update torch-npu dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ matplotlib>=3.7.0
 fire
 packaging
 pyyaml
+numpy<2.0.0


### PR DESCRIPTION
# What does this PR do?

Numpy 2.0.0 版本发布，与 torch 2.1.0 不兼容，会导致以下错误：
![image](https://github.com/hiyouga/LLaMA-Factory/assets/52243582/cb3f814c-c6cb-4a11-b555-534fc3a8d8d2)

该升级只影响 torch-npu 的默认安装使用，不影响最新版 torch

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [N/A] Did you write any new necessary tests?
