### PR TITLE
Fix Windows command preview

### DIFF
--- a/src/llamafactory/webui/utils.py
+++ b/src/llamafactory/webui/utils.py
@@ -113,7 +113,10 @@ def gen_cmd(args: Dict[str, Any]) -> str:
     for k, v in clean_cmd(args).items():
         cmd_lines.append("    --{} {} ".format(k, str(v)))
 
-    cmd_text = "\\\n".join(cmd_lines)
+    if os.name == "nt":
+        cmd_text = "`\n".join(cmd_lines)
+    else:
+        cmd_text = "\\\n".join(cmd_lines)
     cmd_text = "```bash\n{}\n```".format(cmd_text)
     return cmd_text
 


### PR DESCRIPTION
# What does this PR do?

In windows mutiline command should like
```
llamafactory-cli train `
    --stage sft `
    --do_train True `
```

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
