### PR TITLE
chore: Update vllm_engine.py to support vllm version >= 0.5.1

### DIFF
--- a/src/llamafactory/extras/packages.py
+++ b/src/llamafactory/extras/packages.py
@@ -82,6 +82,7 @@ def is_vllm_available():
 def is_vllm_version_greater_than_0_5():
     return _get_package_version("vllm") >= version.parse("0.5.0")
 
+
 @lru_cache
 def is_vllm_version_greater_than_0_5_1():
     return _get_package_version("vllm") >= version.parse("0.5.1")

--- a/src/llamafactory/extras/packages.py
+++ b/src/llamafactory/extras/packages.py
@@ -81,3 +81,7 @@ def is_vllm_available():
 @lru_cache
 def is_vllm_version_greater_than_0_5():
     return _get_package_version("vllm") >= version.parse("0.5.0")
+
+@lru_cache
+def is_vllm_version_greater_than_0_5_1():
+    return _get_package_version("vllm") >= version.parse("0.5.1")


### PR DESCRIPTION
# What does this PR do?
Minimizes modifications to adapt to changes in vllm version 0.5.1 and later (regarding https://github.com/vllm-project/vllm/pull/5852).

Fixes addresses the error encountered when starting the web UI:

```
vllm_engine.py, line 33, in <module>
    from vllm.multimodal.image import ImagePixelData
ImportError: cannot import name 'ImagePixelData' from 'vllm.multimodal.image'
```

**Specific Changes Made**

- **File:** `vllm_engine.py`
  - Updated the import statement for `ImagePixelData` to handle changes in vllm version 0.5.1 and later.
  - Introduced a conditional import to ensure compatibility with versions greater than 0.5.1 and 0.5.0.
  - Updated the logic to handle ImagePixelData and MultiModalData correctly based on the vllm version.

## Before submitting

- [ ✓ ] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?
