### PR TITLE
fix src/llamafactory/train/callbacks.py

### DIFF
--- a/src/llamafactory/train/callbacks.py
+++ b/src/llamafactory/train/callbacks.py
@@ -79,7 +79,7 @@ def fix_valuehead_checkpoint(
         if name.startswith("v_head."):
             v_head_state_dict[name] = param
         else:
-            decoder_state_dict[name.replace("pretrained_model.", "",1)] = param
+            decoder_state_dict[name.replace("pretrained_model.", "", 1)] = param
 
     model.pretrained_model.save_pretrained(
         output_dir, state_dict=decoder_state_dict or None, safe_serialization=safe_serialization

--- a/src/llamafactory/train/callbacks.py
+++ b/src/llamafactory/train/callbacks.py
@@ -79,7 +79,7 @@ def fix_valuehead_checkpoint(
         if name.startswith("v_head."):
             v_head_state_dict[name] = param
         else:
-            decoder_state_dict[name.replace("pretrained_model.", "", count=1)] = param
+            decoder_state_dict[name.replace("pretrained_model.", "",1)] = param
 
     model.pretrained_model.save_pretrained(
         output_dir, state_dict=decoder_state_dict or None, safe_serialization=safe_serialization


### PR DESCRIPTION
# What does this PR do?

Fixes # (issue)

## Before submitting

- [ ] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?


在 examples/train_lora/llama3_lora_reward.yaml 中添加了一行配置使用`deepspeed`， 训练完成后保存模型不成功，报错`TypeError:str.replace()takes no keyword arguments`。配置如下
``` yaml
### model
model_name_or_path: meta-llama/Meta-Llama-3-8B-Instruct

### method
stage: rm
do_train: true
finetuning_type: lora
lora_target: all
deepspeed: examples/deepspeed/ds_z3_config.json

### dataset
dataset: dpo_en_demo
template: llama3
cutoff_len: 1024
max_samples: 50
overwrite_cache: true

### output
output_dir: saves/llama3-8b/lora/rewardfix
logging_steps: 10
save_steps: 500
plot_loss: true
overwrite_output_dir: true

### train
per_device_train_batch_size: 1
gradient_accumulation_steps: 8
learning_rate: 1.0e-4
num_train_epochs: 1.0
lr_scheduler_type: cosine
warmup_ratio: 0.1
bf16: true
ddp_timeout: 180000000

### eval
val_size: 0.1
per_device_eval_batch_size: 1
eval_strategy: steps
eval_steps: 500
```

定位到src/llamafactory/train/callbacks.py的方法fix_valuehead_checkpoint中，修改后可以正确保存模型
![image](https://github.com/hiyouga/LLaMA-Factory/assets/37482011/c52d0a78-8c3d-48b1-a626-585d6325c9d2)
