### PR TITLE
Add Korean web UI (llamafactory-cli webui)

### DIFF
--- a/src/llamafactory/webui/components/top.py
+++ b/src/llamafactory/webui/components/top.py
@@ -33,7 +33,7 @@ def create_top() -> Dict[str, "Component"]:
     available_models = list(SUPPORTED_MODELS.keys()) + ["Custom"]
 
     with gr.Row():
-        lang = gr.Dropdown(choices=["en", "ru", "zh"], scale=1)
+        lang = gr.Dropdown(choices=["en", "ru", "zh", "ko"], scale=1)
         model_name = gr.Dropdown(choices=available_models, scale=3)
         model_path = gr.Textbox(scale=3)
 

--- a/src/llamafactory/webui/locales.py
+++ b/src/llamafactory/webui/locales.py
@@ -23,6 +23,9 @@ LOCALES = {
         "zh": {
             "label": "语言",
         },
+        "ko": {
+            "label": "언어",
+        },
     },
     "model_name": {
         "en": {
@@ -33,6 +36,9 @@ LOCALES = {
         },
         "zh": {
             "label": "模型名称",
+        },
+        "ko": {
+            "label": "모델 이름",
         },
     },
     "model_path": {
@@ -48,6 +54,10 @@ LOCALES = {
             "label": "模型路径",
             "info": "本地模型的文件路径或 Hugging Face 的模型标识符。",
         },
+        "ko": {
+            "label": "모델 경로",
+            "info": "사전 훈련된 모델의 경로 또는 Hugging Face의 모델 식별자.",
+        },
     },
     "finetuning_type": {
         "en": {
@@ -58,6 +68,9 @@ LOCALES = {
         },
         "zh": {
             "label": "微调方法",
+        },
+        "ko": {
+            "label": "파인튜닝 방법",
         },
     },
     "checkpoint_path": {
@@ -70,6 +83,9 @@ LOCALES = {
         "zh": {
             "label": "检查点路径",
         },
+        "ko": {
+            "label": "체크포인트 경로",
+        },
     },
     "advanced_tab": {
         "en": {
@@ -80,6 +96,9 @@ LOCALES = {
         },
         "zh": {
             "label": "高级设置",
+        },
+        "ko": {
+            "label": "고급 설정",
         },
     },
     "quantization_bit": {
@@ -95,6 +114,10 @@ LOCALES = {
             "label": "量化等级",
             "info": "启用量化（QLoRA）。",
         },
+        "ko": {
+            "label": "양자화 비트",
+            "info": "양자화 활성화 (QLoRA).",
+        },
     },
     "quantization_method": {
         "en": {
@@ -108,6 +131,10 @@ LOCALES = {
         "zh": {
             "label": "量化方法",
             "info": "使用的量化算法。",
+        },
+        "ko": {
+            "label": "양자화 방법",
+            "info": "사용할 양자화 알고리즘.",
         },
     },
     "template": {
@@ -123,6 +150,10 @@ LOCALES = {
             "label": "提示模板",
             "info": "构建提示词时使用的模板",
         },
+        "ko": {
+            "label": "프롬프트 템플릿",
+            "info": "프롬프트 구성에 사용될 템플릿.",
+        },
     },
     "rope_scaling": {
         "en": {
@@ -133,6 +164,9 @@ LOCALES = {
         },
         "zh": {
             "label": "RoPE 插值方法",
+        },
+        "ko": {
+            "label": "RoPE 스케일링",
         },
     },
     "booster": {
@@ -145,6 +179,9 @@ LOCALES = {
         "zh": {
             "label": "加速方式",
         },
+        "ko": {
+            "label": "부스터",
+        },
     },
     "visual_inputs": {
         "en": {
@@ -155,6 +192,9 @@ LOCALES = {
         },
         "zh": {
             "label": "图像输入",
+        },
+        "ko": {
+            "label": "시각적 입력",
         },
     },
     "training_stage": {
@@ -170,6 +210,10 @@ LOCALES = {
             "label": "训练阶段",
             "info": "目前采用的训练方式。",
         },
+        "ko": {
+            "label": "학습 단계",
+            "info": "수행할 학습 방법.",
+        },
     },
     "dataset_dir": {
         "en": {
@@ -184,6 +228,10 @@ LOCALES = {
             "label": "数据路径",
             "info": "数据文件夹的路径。",
         },
+        "ko": {
+            "label": "데이터 디렉토리",
+            "info": "데이터 디렉토리의 경로.",
+        },
     },
     "dataset": {
         "en": {
@@ -194,6 +242,9 @@ LOCALES = {
         },
         "zh": {
             "label": "数据集",
+        },
+        "ko": {
+            "label": "데이터셋",
         },
     },
     "data_preview_btn": {
@@ -206,6 +257,9 @@ LOCALES = {
         "zh": {
             "value": "预览数据集",
         },
+        "ko": {
+            "value": "데이터셋 미리보기",
+        },
     },
     "preview_count": {
         "en": {
@@ -216,6 +270,9 @@ LOCALES = {
         },
         "zh": {
             "label": "数量",
+        },
+        "ko": {
+            "label": "개수",
         },
     },
     "page_index": {
@@ -228,6 +285,9 @@ LOCALES = {
         "zh": {
             "label": "页数",
         },
+        "ko": {
+            "label": "페이지",
+        },
     },
     "prev_btn": {
         "en": {
@@ -238,6 +298,9 @@ LOCALES = {
         },
         "zh": {
             "value": "上一页",
+        },
+        "ko": {
+            "value": "이전",
         },
     },
     "next_btn": {
@@ -250,6 +313,9 @@ LOCALES = {
         "zh": {
             "value": "下一页",
         },
+        "ko": {
+            "value": "다음",
+        },
     },
     "close_btn": {
         "en": {
@@ -261,6 +327,9 @@ LOCALES = {
         "zh": {
             "value": "关闭",
         },
+        "ko": {
+            "value": "닫기",
+        },
     },
     "preview_samples": {
         "en": {
@@ -271,6 +340,9 @@ LOCALES = {
         },
         "zh": {
             "label": "样例",
+        },
+        "ko": {
+            "label": "샘플",
         },
     },
     "learning_rate": {
@@ -286,6 +358,11 @@ LOCALES = {
             "label": "学习率",
             "info": "AdamW 优化器的初始学习率。",
         },
+        "ko": {
+            "label": "학습률",
+            "info": "AdamW의 초기 학습률.",
+        },
+
     },
     "num_train_epochs": {
         "en": {
@@ -299,6 +376,10 @@ LOCALES = {
         "zh": {
             "label": "训练轮数",
             "info": "需要执行的训练总轮数。",
+        },
+        "ko": {
+            "label": "에포크",
+            "info": "수행할 총 학습 에포크 수.",
         },
     },
     "max_grad_norm": {
@@ -314,6 +395,10 @@ LOCALES = {
             "label": "最大梯度范数",
             "info": "用于梯度裁剪的范数。",
         },
+        "ko": {
+            "label": "최대 그레디언트 노름(norm)",
+            "info": "그레디언트 클리핑을 위한 노름(norm).",
+        },
     },
     "max_samples": {
         "en": {
@@ -327,6 +412,10 @@ LOCALES = {
         "zh": {
             "label": "最大样本数",
             "info": "每个数据集的最大样本数。",
+        },
+        "ko": {
+            "label": "최대 샘플 수",
+            "info": "데이터셋 당 최대 샘플 수.",
         },
     },
     "compute_type": {
@@ -342,6 +431,10 @@ LOCALES = {
             "label": "计算类型",
             "info": "是否使用混合精度训练。",
         },
+        "ko": {
+            "label": "연산 유형",
+            "info": "혼합 정밀도 훈련을 사용할지 여부.",
+        },
     },
     "cutoff_len": {
         "en": {
@@ -355,6 +448,10 @@ LOCALES = {
         "zh": {
             "label": "截断长度",
             "info": "输入序列分词后的最大长度。",
+        },
+        "ko": {
+            "label": "컷오프 길이",
+            "info": "입력 시퀀스의 최대 토큰 수.",
         },
     },
     "batch_size": {
@@ -370,6 +467,10 @@ LOCALES = {
             "label": "批处理大小",
             "info": "每个 GPU 处理的样本数量。",
         },
+        "ko": {
+            "label": "배치 크기",
+            "info": "각 GPU에서 처리되는 샘플 수.",
+        },
     },
     "gradient_accumulation_steps": {
         "en": {
@@ -383,6 +484,10 @@ LOCALES = {
         "zh": {
             "label": "梯度累积",
             "info": "梯度累积的步数。",
+        },
+        "ko": {
+            "label": "그레디언트 누적",
+            "info": "그레디언트 누적 단계 수.",
         },
     },
     "val_size": {
@@ -398,6 +503,10 @@ LOCALES = {
             "label": "验证集比例",
             "info": "验证集占全部样本的百分比。",
         },
+        "ko": {
+            "label": "검증 데이터셋 크기",
+            "info": "개발 데이터셋에서 검증 데이터의 비율.",
+        },
     },
     "lr_scheduler_type": {
         "en": {
@@ -412,6 +521,10 @@ LOCALES = {
             "label": "学习率调节器",
             "info": "学习率调度器的名称。",
         },
+        "ko": {
+            "label": "LR 스케줄러",
+            "info": "학습률 스케줄러의 이름.",
+        },
     },
     "extra_tab": {
         "en": {
@@ -422,6 +535,9 @@ LOCALES = {
         },
         "zh": {
             "label": "其它参数设置",
+        },
+        "ko": {
+            "label": "추가 구성(configuration)",
         },
     },
     "logging_steps": {
@@ -437,6 +553,10 @@ LOCALES = {
             "label": "日志间隔",
             "info": "每两次日志输出间的更新步数。",
         },
+        "ko": {
+            "label": "로깅 스텝",
+            "info": "이전 로깅과 다음 로깅 간 스텝 수.",
+        },
     },
     "save_steps": {
         "en": {
@@ -450,6 +570,10 @@ LOCALES = {
         "zh": {
             "label": "保存间隔",
             "info": "每两次断点保存间的更新步数。",
+        },
+        "ko": {
+            "label": "저장 스텝",
+            "info": "이전 체크포인트와 다음 체크포인트 사이의 스텝 수.",
         },
     },
     "warmup_steps": {
@@ -465,6 +589,10 @@ LOCALES = {
             "label": "预热步数",
             "info": "学习率预热采用的步数。",
         },
+        "ko": {
+            "label": "Warmup 스텝",
+            "info": "Warmup에 사용되는 스텝 수.",
+        },
     },
     "neftune_alpha": {
         "en": {
@@ -478,6 +606,10 @@ LOCALES = {
         "zh": {
             "label": "NEFTune 噪声参数",
             "info": "嵌入向量所添加的噪声大小。",
+        },
+        "ko": {
+            "label": "NEFTune 알파",
+            "info": "임베딩 벡터에 추가되는 노이즈의 크기.",
         },
     },
     "optim": {
@@ -493,6 +625,10 @@ LOCALES = {
             "label": "优化器",
             "info": "使用的优化器：adamw_torch、adamw_8bit 或 adafactor。",
         },
+        "ko": {
+            "label": "옵티마이저",
+            "info": "사용할 옵티마이저: adamw_torch, adamw_8bit 또는 adafactor 등.",
+        },
     },
     "packing": {
         "en": {
@@ -506,6 +642,10 @@ LOCALES = {
         "zh": {
             "label": "序列打包",
             "info": "将序列打包为等长样本。",
+        },
+        "ko": {
+            "label": "시퀀스 패킹",
+            "info": "고정된 길이의 샘플로 시퀀스를 패킹합니다.",
         },
     },
     "neat_packing": {
@@ -521,6 +661,10 @@ LOCALES = {
             "label": "使用无污染打包",
             "info": "避免打包后的序列产生交叉注意力。",
         },
+        "ko": {
+            "label": "니트 패킹 사용",
+            "info": "패킹된 시퀀스 간의 크로스 어텐션을 피합니다.",
+        },
     },
     "train_on_prompt": {
         "en": {
@@ -534,6 +678,10 @@ LOCALES = {
         "zh": {
             "label": "学习提示词",
             "info": "不在提示词的部分添加掩码（仅适用于 SFT）。",
+        },
+        "ko": {
+            "label": "프롬프트도 학습",
+            "info": "프롬프트에서 라벨 마스킹을 비활성화합니다 (SFT에만 해당).",
         },
     },
     "mask_history": {
@@ -549,6 +697,10 @@ LOCALES = {
             "label": "不学习历史对话",
             "info": "仅学习最后一轮对话（仅适用于 SFT）。",
         },
+        "ko": {
+            "label": "히스토리 마스킹",
+            "info": "대화 데이터의 마지막 턴만 학습합니다 (SFT에만 해당).",
+        },
     },
     "resize_vocab": {
         "en": {
@@ -562,6 +714,10 @@ LOCALES = {
         "zh": {
             "label": "更改词表大小",
             "info": "更改分词器词表和嵌入层的大小。",
+        },
+        "ko": {
+            "label": "토큰 임베딩의 사이즈 조정",
+            "info": "토크나이저 어휘와 임베딩 레이어의 크기를 조정합니다.",
         },
     },
     "use_llama_pro": {
@@ -577,6 +733,10 @@ LOCALES = {
             "label": "使用 LLaMA Pro",
             "info": "仅训练块扩展后的参数。",
         },
+        "ko": {
+            "label": "LLaMA Pro 사용",
+            "info": "확장된 블록의 매개변수를 학습 가능하게 만듭니다.",
+        },
     },
     "shift_attn": {
         "en": {
@@ -590,6 +750,10 @@ LOCALES = {
         "zh": {
             "label": "使用 S^2 Attention",
             "info": "使用 LongLoRA 提出的 shift short attention。",
+        },
+        "ko": {
+            "label": "S^2 Attention 사용",
+            "info": "LongLoRA에서 제안한 shift short attention을 사용합니다.",
         },
     },
     "report_to": {
@@ -605,6 +769,10 @@ LOCALES = {
             "label": "启用外部记录面板",
             "info": "使用 TensorBoard 或 wandb 记录实验。",
         },
+        "ko": {
+            "label": "외부 logger 활성화",
+            "info": "TensorBoard 또는 wandb를 사용하여 실험을 기록합니다.",
+        },
     },
     "freeze_tab": {
         "en": {
@@ -615,6 +783,9 @@ LOCALES = {
         },
         "zh": {
             "label": "部分参数微调设置",
+        },
+        "ko": {
+            "label": "Freeze tuning 설정",
         },
     },
     "freeze_trainable_layers": {
@@ -630,6 +801,10 @@ LOCALES = {
             "label": "可训练层数",
             "info": "最末尾（+）/最前端（-）可训练隐藏层的数量。",
         },
+        "ko": {
+            "label": "학습 가능한 레이어",
+            "info": "학습 가능하게 설정할 마지막(+)/처음(-) 히든 레이어의 수.",
+        },
     },
     "freeze_trainable_modules": {
         "en": {
@@ -643,6 +818,10 @@ LOCALES = {
         "zh": {
             "label": "可训练模块",
             "info": "可训练模块的名称。使用英文逗号分隔多个名称。",
+        },
+        "ko": {
+            "label": "학습 가능한 모듈",
+            "info": "학습 가능한 모듈의 이름. 여러 모듈을 구분하려면 쉼표(,)를 사용하세요.",
         },
     },
     "freeze_extra_modules": {
@@ -664,6 +843,10 @@ LOCALES = {
             "label": "额外模块（非必填）",
             "info": "除隐藏层以外的可训练模块名称。使用英文逗号分隔多个名称。",
         },
+        "ko": {
+            "label": "추가 모듈 (선택 사항)",
+            "info": "학습 가능한 모듈의 이름(히든 레이어 제외). 모듈 간에는 쉼표(,)로 구분하십시오.",
+        },
     },
     "lora_tab": {
         "en": {
@@ -674,6 +857,9 @@ LOCALES = {
         },
         "zh": {
             "label": "LoRA 参数设置",
+        },
+        "ko": {
+            "label": "LoRA 구성",
         },
     },
     "lora_rank": {
@@ -689,6 +875,10 @@ LOCALES = {
             "label": "LoRA 秩",
             "info": "LoRA 矩阵的秩大小。",
         },
+        "ko": {
+            "label": "LoRA 랭크",
+            "info": "LoRA 행렬의 랭크.",
+        },
     },
     "lora_alpha": {
         "en": {
@@ -702,6 +892,10 @@ LOCALES = {
         "zh": {
             "label": "LoRA 缩放系数",
             "info": "LoRA 缩放系数大小。",
+        },
+        "ko": {
+            "label": "LoRA 알파",
+            "info": "LoRA 스케일링 계수.",
         },
     },
     "lora_dropout": {
@@ -717,6 +911,10 @@ LOCALES = {
             "label": "LoRA 随机丢弃",
             "info": "LoRA 权重随机丢弃的概率。",
         },
+        "ko": {
+            "label": "LoRA 드롭아웃",
+            "info": "LoRA 가중치의 드롭아웃 비율.",
+        },
     },
     "loraplus_lr_ratio": {
         "en": {
@@ -730,6 +928,10 @@ LOCALES = {
         "zh": {
             "label": "LoRA+ 学习率比例",
             "info": "LoRA+ 中 B 矩阵的学习率倍数。",
+        },
+        "ko": {
+            "label": "LoRA+ LR 비율",
+            "info": "LoRA에서 B 행렬의 LR 비율.",
         },
     },
     "create_new_adapter": {
@@ -745,6 +947,10 @@ LOCALES = {
             "label": "新建适配器",
             "info": "在现有的适配器上创建一个随机初始化后的新适配器。",
         },
+        "ko": {
+            "label": "새 어댑터 생성",
+            "info": "기존 어댑터 위에 무작위로 초기화된 가중치를 가진 새 어댑터를 생성합니다.",
+        },
     },
     "use_rslora": {
         "en": {
@@ -758,6 +964,10 @@ LOCALES = {
         "zh": {
             "label": "使用 rslora",
             "info": "对 LoRA 层使用秩稳定缩放方法。",
+        },
+        "ko": {
+            "label": "rslora 사용",
+            "info": "LoRA 레이어에 랭크 안정화 스케일링 계수를 사용합니다.",
         },
     },
     "use_dora": {
@@ -773,6 +983,10 @@ LOCALES = {
             "label": "使用 DoRA",
             "info": "使用权重分解的 LoRA。",
         },
+        "ko": {
+            "label": "DoRA 사용",
+            "info": "가중치-분해 LoRA를 사용합니다.",
+        },
     },
     "use_pissa": {
         "en": {
@@ -787,6 +1001,10 @@ LOCALES = {
             "label": "使用 PiSSA",
             "info": "使用 PiSSA 方法。",
         },
+        "ko": {
+            "label": "PiSSA 사용",
+            "info": "PiSSA 방법을 사용합니다.",
+        },
     },
     "lora_target": {
         "en": {
@@ -800,6 +1018,10 @@ LOCALES = {
         "zh": {
             "label": "LoRA 作用模块（非必填）",
             "info": "应用 LoRA 的模块名称。使用英文逗号分隔多个名称。",
+        },
+        "ko": {
+            "label": "LoRA 모듈 (선택 사항)",
+            "info": "LoRA를 적용할 모듈의 이름. 모듈 간에는 쉼표(,)로 구분하십시오.",
         },
     },
     "additional_target": {
@@ -821,6 +1043,10 @@ LOCALES = {
             "label": "附加模块（非必填）",
             "info": "除 LoRA 层以外的可训练模块名称。使用英文逗号分隔多个名称。",
         },
+        "ko": {
+            "label": "추가 모듈 (선택 사항)",
+            "info": "LoRA 레이어 외에 학습 가능하게 설정할 모듈의 이름. 모듈 간에는 쉼표(,)로 구분하십시오.",
+        },
     },
     "rlhf_tab": {
         "en": {
@@ -831,6 +1057,9 @@ LOCALES = {
         },
         "zh": {
             "label": "RLHF 参数设置",
+        },
+        "ko": {
+            "label": "RLHF 구성",
         },
     },
     "pref_beta": {
@@ -846,6 +1075,10 @@ LOCALES = {
             "label": "Beta 参数",
             "info": "损失函数中 beta 超参数大小。",
         },
+        "ko": {
+            "label": "베타 값",
+            "info": "손실 함수에서 베타 매개 변수의 값.",
+        },
     },
     "pref_ftx": {
         "en": {
@@ -859,6 +1092,10 @@ LOCALES = {
         "zh": {
             "label": "Ftx gamma",
             "info": "损失函数中 SFT 损失的权重大小。",
+        },
+        "ko": {
+            "label": "Ftx 감마",
+            "info": "최종 로스 함수에서 SFT 로스의 가중치.",
         },
     },
     "pref_loss": {
@@ -874,6 +1111,10 @@ LOCALES = {
             "label": "损失类型",
             "info": "损失函数的类型。",
         },
+        "ko": {
+            "label": "로스 유형",
+            "info": "로스 함수의 유형.",
+        },
     },
     "reward_model": {
         "en": {
@@ -887,6 +1128,10 @@ LOCALES = {
         "zh": {
             "label": "奖励模型",
             "info": "PPO 训练中奖励模型的适配器路径。",
+        },
+        "ko": {
+            "label": "리워드 모델",
+            "info": "PPO 학습에서 사용할 리워드 모델의 어댑터.",
         },
     },
     "ppo_score_norm": {
@@ -902,6 +1147,10 @@ LOCALES = {
             "label": "奖励模型",
             "info": "PPO 训练中归一化奖励分数。",
         },
+        "ko": {
+            "label": "스코어 정규화",
+            "info": "PPO 학습에서 스코어를 정규화합니다.",
+        },
     },
     "ppo_whiten_rewards": {
         "en": {
@@ -916,6 +1165,10 @@ LOCALES = {
             "label": "白化奖励",
             "info": "PPO 训练中将奖励分数做白化处理。",
         },
+        "ko": {
+            "label": "보상 백화",
+            "info": "PPO 훈련에서 보상을 백화(Whiten)합니다.",
+        },
     },
     "galore_tab": {
         "en": {
@@ -926,6 +1179,9 @@ LOCALES = {
         },
         "zh": {
             "label": "GaLore 参数设置",
+        },
+        "ko": {
+            "label": "GaLore 구성",
         },
     },
     "use_galore": {
@@ -941,6 +1197,10 @@ LOCALES = {
             "label": "使用 GaLore",
             "info": "使用梯度低秩投影。",
         },
+        "ko": {
+            "label": "GaLore 사용",
+            "info": "그레디언트 로우 랭크 프로젝션을 활성화합니다.",
+        },
     },
     "galore_rank": {
         "en": {
@@ -954,6 +1214,10 @@ LOCALES = {
         "zh": {
             "label": "GaLore 秩",
             "info": "GaLore 梯度的秩大小。",
+        },
+        "ko": {
+            "label": "GaLore 랭크",
+            "info": "GaLore 그레디언트의 랭크.",
         },
     },
     "galore_update_interval": {
@@ -969,6 +1233,10 @@ LOCALES = {
             "label": "更新间隔",
             "info": "相邻两次投影更新的步数。",
         },
+        "ko": {
+            "label": "업데이트 간격",
+            "info": "GaLore 프로젝션을 업데이트할 간격의 스텝 수.",
+        },
     },
     "galore_scale": {
         "en": {
@@ -982,6 +1250,10 @@ LOCALES = {
         "zh": {
             "label": "GaLore 缩放系数",
             "info": "GaLore 缩放系数大小。",
+        },
+        "ko": {
+            "label": "GaLore 스케일",
+            "info": "GaLore 스케일링 계수.",
         },
     },
     "galore_target": {
@@ -997,6 +1269,10 @@ LOCALES = {
             "label": "GaLore 作用模块",
             "info": "应用 GaLore 的模块名称。使用英文逗号分隔多个名称。",
         },
+        "ko": {
+            "label": "GaLore 모듈",
+            "info": "GaLore를 적용할 모듈의 이름. 모듈 간에는 쉼표(,)로 구분하십시오.",
+        },
     },
     "badam_tab": {
         "en": {
@@ -1007,6 +1283,9 @@ LOCALES = {
         },
         "zh": {
             "label": "BAdam 参数设置",
+        },
+        "ko": {
+            "label": "BAdam 설정",
         },
     },
     "use_badam": {
@@ -1022,6 +1301,10 @@ LOCALES = {
             "label": "使用 BAdam",
             "info": "使用 BAdam 优化器。",
         },
+        "ko": {
+            "label": "BAdam 사용",
+            "info": "BAdam 옵티마이저를 사용합니다.",
+        },
     },
     "badam_mode": {
         "en": {
@@ -1035,6 +1318,10 @@ LOCALES = {
         "zh": {
             "label": "BAdam 模式",
             "info": "使用 layer-wise 或 ratio-wise BAdam 优化器。",
+        },
+        "ko": {
+            "label": "BAdam 모드",
+            "info": "레이어-BAdam 옵티마이저인지 비율-BAdam 옵티마이저인지.",
         },
     },
     "badam_switch_mode": {
@@ -1050,6 +1337,10 @@ LOCALES = {
             "label": "切换策略",
             "info": "Layer-wise BAdam 优化器的块切换策略。",
         },
+        "ko": {
+            "label": "스위치 모드",
+            "info": "레이어-BAdam을 위한 블록 선택 전략.",
+        },
     },
     "badam_switch_interval": {
         "en": {
@@ -1063,6 +1354,10 @@ LOCALES = {
         "zh": {
             "label": "切换频率",
             "info": "Layer-wise BAdam 优化器的块切换频率。",
+        },
+        "ko": {
+            "label": "전환 간격",
+            "info": "레이어-BAdam을 위한 블록 업데이트 간 스텝 수.",
         },
     },
     "badam_update_ratio": {
@@ -1078,6 +1373,10 @@ LOCALES = {
             "label": "Block 更新比例",
             "info": "Ratio-wise BAdam 优化器的更新比例。",
         },
+        "ko": {
+            "label": "업데이트 비율",
+            "info": "비율-BAdam의 업데이트 비율.",
+        },
     },
     "cmd_preview_btn": {
         "en": {
@@ -1088,6 +1387,9 @@ LOCALES = {
         },
         "zh": {
             "value": "预览命令",
+        },
+        "ko": {
+            "value": "명령어 미리보기",
         },
     },
     "arg_save_btn": {
@@ -1100,6 +1402,9 @@ LOCALES = {
         "zh": {
             "value": "保存训练参数",
         },
+        "ko": {
+            "value": "Argument 저장",
+        },
     },
     "arg_load_btn": {
         "en": {
@@ -1110,6 +1415,9 @@ LOCALES = {
         },
         "zh": {
             "value": "载入训练参数",
+        },
+        "ko": {
+            "value": "Argument 불러오기",
         },
     },
     "start_btn": {
@@ -1122,6 +1430,9 @@ LOCALES = {
         "zh": {
             "value": "开始",
         },
+        "ko": {
+            "value": "시작",
+        },
     },
     "stop_btn": {
         "en": {
@@ -1132,6 +1443,9 @@ LOCALES = {
         },
         "zh": {
             "value": "中断",
+        },
+        "ko": {
+            "value": "중단",
         },
     },
     "output_dir": {
@@ -1147,6 +1461,10 @@ LOCALES = {
             "label": "输出目录",
             "info": "保存结果的路径。",
         },
+        "ko": {
+            "label": "출력 디렉토리",
+            "info": "결과를 저장할 디렉토리.",
+        },
     },
     "config_path": {
         "en": {
@@ -1160,6 +1478,10 @@ LOCALES = {
         "zh": {
             "label": "配置路径",
             "info": "保存训练参数的配置文件路径。",
+        },
+        "ko": {
+            "label": "설정 경로",
+            "info": "Arguments 저장 파일 경로.",
         },
     },
     "device_count": {
@@ -1175,6 +1497,10 @@ LOCALES = {
             "label": "设备数量",
             "info": "当前可用的运算设备数。",
         },
+        "ko": {
+            "label": "디바이스 수",
+            "info": "사용 가능한 디바이스 수.",
+        },
     },
     "ds_stage": {
         "en": {
@@ -1188,6 +1514,10 @@ LOCALES = {
         "zh": {
             "label": "DeepSpeed stage",
             "info": "多卡训练的 DeepSpeed stage。",
+        },
+        "ko": {
+            "label": "DeepSpeed 단계",
+            "info": "분산 학습을 위한 DeepSpeed 단계.",
         },
     },
     "ds_offload": {
@@ -1203,6 +1533,10 @@ LOCALES = {
             "label": "使用 offload",
             "info": "使用 DeepSpeed offload（会减慢速度）。",
         },
+        "ko": {
+            "label": "오프로딩 활성화",
+            "info": "DeepSpeed 오프로딩 활성화 (훈련 속도 느려짐).",
+        },
     },
     "output_box": {
         "en": {
@@ -1213,6 +1547,9 @@ LOCALES = {
         },
         "zh": {
             "value": "准备就绪。",
+        },
+        "ko": {
+            "value": "준비 완료.",
         },
     },
     "loss_viewer": {
@@ -1225,6 +1562,9 @@ LOCALES = {
         "zh": {
             "label": "损失",
         },
+        "ko": {
+            "label": "손실",
+        },
     },
     "predict": {
         "en": {
@@ -1235,6 +1575,9 @@ LOCALES = {
         },
         "zh": {
             "label": "保存预测结果",
+        },
+        "ko": {
+            "label": "예측 결과 저장",
         },
     },
     "infer_backend": {
@@ -1247,6 +1590,9 @@ LOCALES = {
         "zh": {
             "label": "推理引擎",
         },
+        "ko": {
+            "label": "추론 엔진",
+        },
     },
     "infer_dtype": {
         "en": {
@@ -1257,6 +1603,9 @@ LOCALES = {
         },
         "zh": {
             "label": "推理数据类型",
+        },
+        "ko": {
+            "label": "추론 데이터 유형",
         },
     },
     "load_btn": {
@@ -1269,6 +1618,9 @@ LOCALES = {
         "zh": {
             "value": "加载模型",
         },
+        "ko": {
+            "value": "모델 불러오기",
+        },
     },
     "unload_btn": {
         "en": {
@@ -1279,6 +1631,9 @@ LOCALES = {
         },
         "zh": {
             "value": "卸载模型",
+        },
+        "ko": {
+            "value": "모델 언로드",
         },
     },
     "info_box": {
@@ -1291,6 +1646,9 @@ LOCALES = {
         "zh": {
             "value": "模型未加载，请先加载模型。",
         },
+        "ko": {
+            "value": "모델이 언로드되었습니다. 모델을 먼저 불러오십시오.",
+        },
     },
     "role": {
         "en": {
@@ -1301,6 +1659,9 @@ LOCALES = {
         },
         "zh": {
             "label": "角色",
+        },
+        "ko": {
+            "label": "역할",
         },
     },
     "system": {
@@ -1313,6 +1674,9 @@ LOCALES = {
         "zh": {
             "placeholder": "系统提示词（非必填）",
         },
+        "ko": {
+            "placeholder": "시스템 프롬프트 (선택 사항)",
+        },
     },
     "tools": {
         "en": {
@@ -1323,6 +1687,9 @@ LOCALES = {
         },
         "zh": {
             "placeholder": "工具列表（非必填）",
+        },
+        "ko": {
+            "placeholder": "툴 (선택 사항)",
         },
     },
     "image": {
@@ -1335,6 +1702,9 @@ LOCALES = {
         "zh": {
             "label": "图像（非必填）",
         },
+        "ko": {
+            "label": "이미지 (선택 사항)",
+        },
     },
     "query": {
         "en": {
@@ -1345,6 +1715,9 @@ LOCALES = {
         },
         "zh": {
             "placeholder": "输入...",
+        },
+        "ko": {
+            "placeholder": "입력...",
         },
     },
     "submit_btn": {
@@ -1357,6 +1730,9 @@ LOCALES = {
         "zh": {
             "value": "提交",
         },
+        "ko": {
+            "value": "제출",
+        },
     },
     "max_length": {
         "en": {
@@ -1367,6 +1743,9 @@ LOCALES = {
         },
         "zh": {
             "label": "最大长度",
+        },
+        "ko": {
+            "label": "최대 길이",
         },
     },
     "max_new_tokens": {
@@ -1379,6 +1758,9 @@ LOCALES = {
         "zh": {
             "label": "最大生成长度",
         },
+        "ko": {
+            "label": "응답의 최대 길이",
+        },
     },
     "top_p": {
         "en": {
@@ -1389,6 +1771,9 @@ LOCALES = {
         },
         "zh": {
             "label": "Top-p 采样值",
+        },
+        "ko": {
+            "label": "Top-p",
         },
     },
     "temperature": {
@@ -1401,6 +1786,9 @@ LOCALES = {
         "zh": {
             "label": "温度系数",
         },
+        "ko": {
+            "label": "온도",
+        },
     },
     "clear_btn": {
         "en": {
@@ -1411,6 +1799,9 @@ LOCALES = {
         },
         "zh": {
             "value": "清空历史",
+        },
+        "ko": {
+            "value": "기록 지우기",
         },
     },
     "export_size": {
@@ -1426,6 +1817,10 @@ LOCALES = {
             "label": "最大分块大小（GB）",
             "info": "单个模型文件的最大大小。",
         },
+        "ko": {
+            "label": "최대 샤드 크기 (GB)",
+            "info": "모델 파일의 최대 크기.",
+        },
     },
     "export_quantization_bit": {
         "en": {
@@ -1439,6 +1834,10 @@ LOCALES = {
         "zh": {
             "label": "导出量化等级",
             "info": "量化导出模型。",
+        },
+        "ko": {
+            "label": "양자화 비트 내보내기",
+            "info": "내보낸 모델의 양자화.",
         },
     },
     "export_quantization_dataset": {
@@ -1454,6 +1853,10 @@ LOCALES = {
             "label": "导出量化数据集",
             "info": "量化过程中使用的校准数据集。",
         },
+        "ko": {
+            "label": "양자화 데이터셋 내보내기",
+            "info": "양자화에 사용되는 교정 데이터셋.",
+        },
     },
     "export_device": {
         "en": {
@@ -1467,6 +1870,10 @@ LOCALES = {
         "zh": {
             "label": "导出设备",
             "info": "导出模型使用的设备类型。",
+        },
+        "ko": {
+            "label": "내보낼 장치",
+            "info": "모델을 내보내는 데 사용할 장치.",
         },
     },
     "export_legacy_format": {
@@ -1482,6 +1889,10 @@ LOCALES = {
             "label": "导出旧格式",
             "info": "不使用 safetensors 格式保存模型。",
         },
+        "ko": {
+            "label": "레거시 형식 내보내기",
+            "info": "모델을 저장하는 데 safetensors를 사용하지 않습니다.",
+        },
     },
     "export_dir": {
         "en": {
@@ -1495,6 +1906,10 @@ LOCALES = {
         "zh": {
             "label": "导出目录",
             "info": "保存导出模型的文件夹路径。",
+        },
+        "ko": {
+            "label": "내보내기 디렉토리",
+            "info": "내보낸 모델을 저장할 디렉토리.",
         },
     },
     "export_hub_model_id": {
@@ -1510,6 +1925,10 @@ LOCALES = {
             "label": "HF Hub ID（非必填）",
             "info": "用于将模型上传至 Hugging Face Hub 的仓库 ID。",
         },
+        "ko": {
+            "label": "HF 허브 ID (선택 사항)",
+            "info": "모델을 Hugging Face 허브에 업로드하기 위한 레포 ID.",
+        },
     },
     "export_btn": {
         "en": {
@@ -1521,6 +1940,9 @@ LOCALES = {
         "zh": {
             "value": "开始导出",
         },
+        "ko": {
+            "value": "내보내기",
+        },
     },
 }
 
@@ -1530,140 +1952,168 @@ ALERTS = {
         "en": "A process is in running, please abort it first.",
         "ru": "Процесс уже запущен, пожалуйста, сначала прервите его.",
         "zh": "任务已存在，请先中断训练。",
+        "ko": "프로세스가 실행 중입니다. 먼저 중단하십시오.",
     },
     "err_exists": {
         "en": "You have loaded a model, please unload it first.",
         "ru": "Вы загрузили модель, сначала разгрузите ее.",
         "zh": "模型已存在，请先卸载模型。",
+        "ko": "모델이 로드되었습니다. 먼저 언로드하십시오.",
     },
     "err_no_model": {
         "en": "Please select a model.",
         "ru": "Пожалуйста, выберите модель.",
         "zh": "请选择模型。",
+        "ko": "모델을 선택하십시오.",
     },
     "err_no_path": {
         "en": "Model not found.",
         "ru": "Модель не найдена.",
         "zh": "模型未找到。",
+        "ko": "모델을 찾을 수 없습니다.",
     },
     "err_no_dataset": {
         "en": "Please choose a dataset.",
         "ru": "Пожалуйста, выберите набор данных.",
         "zh": "请选择数据集。",
+        "ko": "데이터 세트를 선택하십시오.",
     },
     "err_no_adapter": {
         "en": "Please select an adapter.",
         "ru": "Пожалуйста, выберите адаптер.",
         "zh": "请选择适配器。",
+        "ko": "어댑터를 선택하십시오.",
     },
     "err_no_output_dir": {
         "en": "Please provide output dir.",
         "ru": "Пожалуйста, укажите выходную директорию.",
         "zh": "请填写输出目录。",
+        "ko": "출력 디렉토리를 제공하십시오.",
     },
     "err_no_reward_model": {
         "en": "Please select a reward model.",
         "ru": "Пожалуйста, выберите модель вознаграждения.",
         "zh": "请选择奖励模型。",
+        "ko": "리워드 모델을 선택하십시오.",
     },
     "err_no_export_dir": {
         "en": "Please provide export dir.",
         "ru": "Пожалуйста, укажите каталог для экспорта.",
         "zh": "请填写导出目录。",
+        "ko": "Export 디렉토리를 제공하십시오.",
     },
     "err_gptq_lora": {
         "en": "Please merge adapters before quantizing the model.",
         "ru": "Пожалуйста, объедините адаптеры перед квантованием модели.",
         "zh": "量化模型前请先合并适配器。",
+        "ko": "모델을 양자화하기 전에 어댑터를 병합하십시오.",
     },
     "err_failed": {
         "en": "Failed.",
         "ru": "Ошибка.",
         "zh": "训练出错。",
+        "ko": "실패했습니다.",
     },
     "err_demo": {
         "en": "Training is unavailable in demo mode, duplicate the space to a private one first.",
         "ru": "Обучение недоступно в демонстрационном режиме, сначала скопируйте пространство в частное.",
         "zh": "展示模式不支持训练，请先复制到私人空间。",
+        "ko": "데모 모드에서는 훈련을 사용할 수 없습니다. 먼저 프라이빗 레포지토리로 작업 공간을 복제하십시오.",
     },
     "err_tool_name": {
         "en": "Tool name not found.",
         "ru": "Имя инструмента не найдено.",
         "zh": "工具名称未找到。",
+        "ko": "툴 이름을 찾을 수 없습니다.",
     },
     "err_json_schema": {
         "en": "Invalid JSON schema.",
         "ru": "Неверная схема JSON.",
         "zh": "Json 格式错误。",
+        "ko": "잘못된 JSON 스키마입니다.",
     },
     "err_config_not_found": {
         "en": "Config file is not found.",
         "ru": "Файл конфигурации не найден.",
         "zh": "未找到配置文件。",
+        "ko": "Config 파일을 찾을 수 없습니다.",
     },
     "warn_no_cuda": {
         "en": "CUDA environment was not detected.",
         "ru": "Среда CUDA не обнаружена.",
         "zh": "未检测到 CUDA 环境。",
+        "ko": "CUDA 환경이 감지되지 않았습니다.",
     },
     "warn_output_dir_exists": {
         "en": "Output dir already exists, will resume training from here.",
         "ru": "Выходной каталог уже существует, обучение будет продолжено отсюда.",
         "zh": "输出目录已存在，将从该断点恢复训练。",
+        "ko": "출력 디렉토리가 이미 존재합니다. 위 출력 디렉토리에 저장된 학습을 재개합니다.",
     },
     "info_aborting": {
         "en": "Aborted, wait for terminating...",
         "ru": "Прервано, ожидание завершения...",
         "zh": "训练中断，正在等待进程结束……",
+        "ko": "중단되었습니다. 종료를 기다리십시오...",
     },
     "info_aborted": {
         "en": "Ready.",
         "ru": "Готово.",
         "zh": "准备就绪。",
+        "ko": "준비되었습니다.",
     },
     "info_finished": {
         "en": "Finished.",
         "ru": "Завершено.",
         "zh": "训练完毕。",
+        "ko": "완료되었습니다.",
     },
     "info_config_saved": {
         "en": "Arguments have been saved at: ",
         "ru": "Аргументы были сохранены по адресу: ",
         "zh": "训练参数已保存至：",
+        "ko": "매개변수가 저장되었습니다: ",
     },
     "info_config_loaded": {
         "en": "Arguments have been restored.",
         "ru": "Аргументы были восстановлены.",
         "zh": "训练参数已载入。",
+        "ko": "매개변수가 복원되었습니다.",
     },
     "info_loading": {
         "en": "Loading model...",
         "ru": "Загрузка модели...",
         "zh": "加载中……",
+        "ko": "모델 로딩 중...",
     },
     "info_unloading": {
         "en": "Unloading model...",
         "ru": "Выгрузка модели...",
         "zh": "卸载中……",
+        "ko": "모델 언로딩 중...",
     },
     "info_loaded": {
         "en": "Model loaded, now you can chat with your model!",
         "ru": "Модель загружена, теперь вы можете общаться с вашей моделью!",
         "zh": "模型已加载，可以开始聊天了！",
+        "ko": "모델이 로드되었습니다. 이제 모델과 채팅할 수 있습니다!",
     },
     "info_unloaded": {
         "en": "Model unloaded.",
         "ru": "Модель выгружена.",
         "zh": "模型已卸载。",
+        "ko": "모델이 언로드되었습니다.",
     },
     "info_exporting": {
         "en": "Exporting model...",
         "ru": "Экспорт модели...",
         "zh": "正在导出模型……",
+        "ko": "모델 내보내기 중...",
     },
     "info_exported": {
         "en": "Model exported.",
         "ru": "Модель экспортирована.",
         "zh": "模型导出完成。",
+        "ko": "모델이 내보내졌습니다.",
     },
 }


### PR DESCRIPTION
# What does this PR do?

[Add] This PR adds Korean translations for the web UI in the `llamafactory-cli webui`.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests? 

## Description

This pull request enhances the web UI by including Korean translations for all interface elements. 
It ensures that Korean users can fully interact with the llamafactory in their native language.

## Changes Made

- Added Korean translations for all UI elements.

> Updated the `LOCALES` dictionary to include Korean (`ko`) entries. (src/llamafactory/webui/locales.py)

>  Ensured consistency and accuracy of the translations.

## Additional Notes

<img width="1516" alt="image" src="https://github.com/user-attachments/assets/22418cb2-7aea-4875-8c6c-f6a844f23575">
