### PR TITLE
fix the deepseekcoder template to avoid repeat problem

### DIFF
--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -586,8 +586,7 @@ _register_template(
 _register_template(
     name="deepseekcoder",
     format_user=StringFormatter(slots=["### Instruction:\n{{content}}\n### Response:"]),
-    format_assistant=StringFormatter(slots=["\n{{content}}\n"]),
-    format_separator=EmptyFormatter(slots=["\n"]),
+    format_assistant=StringFormatter(slots=["{{content}}\n<|EOT|>"]),
     format_prefix=EmptyFormatter(slots=[{"bos_token"}]),
     default_system=(
         "You are an AI programming assistant, utilizing the Deepseek Coder model, "
@@ -595,6 +594,8 @@ _register_template(
         "For politically sensitive questions, security and privacy issues, "
         "and other non-computer science questions, you will refuse to answer\n"
     ),
+    stop_words=["<|EOT|>"],
+    replace_eos=True,
 )
 
 

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -586,7 +586,8 @@ _register_template(
 _register_template(
     name="deepseekcoder",
     format_user=StringFormatter(slots=["### Instruction:\n{{content}}\n### Response:"]),
-    format_assistant=StringFormatter(slots=["{{content}}\n<|EOT|>"]),
+    format_assistant=StringFormatter(slots=["\n{{content}}\n<|EOT|>"]),
+    format_separator=EmptyFormatter(slots=["\n"]),
     format_prefix=EmptyFormatter(slots=[{"bos_token"}]),
     default_system=(
         "You are an AI programming assistant, utilizing the Deepseek Coder model, "
@@ -594,8 +595,6 @@ _register_template(
         "For politically sensitive questions, security and privacy issues, "
         "and other non-computer science questions, you will refuse to answer\n"
     ),
-    stop_words=["<|EOT|>"],
-    replace_eos=True,
 )
 
 


### PR DESCRIPTION
# What does this PR do?

I fixed the template for DeepSeek-Coder. The reference link for the template is as follows:

https://github.com/deepseek-ai/DeepSeek-Coder/blob/b7ba565956fe61153064f288862daf1896de5393/finetune/finetune_deepseekcoder.py#L16

The main change was the addition of the `"<|EOT|>"` token, which ensures that the trained model does not generate infinitely due to the lack of an end-of-sequence marker. I have trained the relevant models and compared them, finding that the new version of the template perfectly solves the problem.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?
