### PR TITLE
支持无 label 推理，修复无 label 推理时速度过慢的问题

### DIFF
--- a/src/llamafactory/data/processors/unsupervised.py
+++ b/src/llamafactory/data/processors/unsupervised.py
@@ -97,6 +97,8 @@ def preprocess_unsupervised_dataset(
             model_inputs["pixel_values"].append(get_pixel_values(examples["images"][i], processor))
             if hasattr(processor, "image_seq_length"):  # paligemma models
                 model_inputs["token_type_ids"].append(get_paligemma_token_type_ids(len(input_ids), processor))
+    if not examples['response'][0]:  # pop labels if response is not str
+        model_inputs.pop('labels')
 
     return model_inputs
 

--- a/src/llamafactory/train/sft/trainer.py
+++ b/src/llamafactory/train/sft/trainer.py
@@ -88,9 +88,10 @@ class CustomSeq2SeqTrainer(Seq2SeqTrainer):
         Subclass and override to inject custom behavior.
         """
         labels = inputs["labels"].detach().clone() if "labels" in inputs else None  # backup labels
-        if self.args.predict_with_generate:
+        prompt_len = inputs["input_ids"].size(-1)
+        if labels is not None and self.args.predict_with_generate:
             assert self.tokenizer.padding_side == "left", "This method only accepts left-padded tensor."
-            prompt_len, label_len = inputs["input_ids"].size(-1), inputs["labels"].size(-1)
+            label_len = inputs["labels"].size(-1)
             if prompt_len > label_len:
                 inputs["labels"] = self._pad_tensors_to_target_len(inputs["labels"], inputs["input_ids"])
             if label_len > prompt_len:  # truncate the labels instead of padding the inputs (llama2 fp16 compatibility)


### PR DESCRIPTION
# What does this PR do?

Fixes # (issue)

数据集里不含标签（output）时，当前代码仍然会自动生成 label，并计算 loss：[https://github.com/hiyouga/LLaMA-Factory/blob/main/src/llamafactory/data/processors/unsupervised.py#L48](https://github.com/hiyouga/LLaMA-Factory/blob/main/src/llamafactory/data/processors/unsupervised.py#L48)。但计算 loss 时，transformer 里Seq2SeqTrainer 会重复做一次推理：[https://github.com/huggingface/transformers/blob/main/src/transformers/trainer_seq2seq.py#L327-L333](https://github.com/huggingface/transformers/blob/main/src/transformers/trainer_seq2seq.py#L327-L333)。因此通过这一 pull request 来规避这一问题。

