### PR TITLE
fix: `Train on the last turn only` truncate bug

### DIFF
--- a/src/llamafactory/data/loader.py
+++ b/src/llamafactory/data/loader.py
@@ -206,6 +206,8 @@ def get_dataset(
     template = get_template_and_fix_tokenizer(tokenizer, data_args.template, data_args.tool_format)
     if data_args.train_on_prompt and template.efficient_eos:
         raise ValueError("Current template does not support `train_on_prompt`.")
+    if stage!="sft" and data_args.mask_history:
+        raise ValueError("`Train on the last turn only` is only valid for sft training.")
 
     # Load tokenized dataset
     if data_args.tokenized_path is not None:

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -69,12 +69,16 @@ class Template:
         messages: Sequence[Dict[str, str]],
         system: Optional[str] = None,
         tools: Optional[str] = None,
+        mask_history: bool = False,
     ) -> List[Tuple[List[int], List[int]]]:
         r"""
         Returns multiple pairs of token ids representing prompts and responses respectively.
         """
         encoded_messages = self._encode(tokenizer, messages, system, tools)
-        return [(encoded_messages[i], encoded_messages[i + 1]) for i in range(0, len(encoded_messages), 2)]
+        if not mask_history:
+            return [(encoded_messages[i], encoded_messages[i + 1]) for i in range(0, len(encoded_messages), 2)]
+        else:
+            return [(encoded_messages[i], encoded_messages[i + 1]) for i in range(len(encoded_messages)-2, -1, -2)]
 
     def extract_tool(self, content: str) -> Union[str, List[Tuple[str, str]]]:
         r"""

--- a/src/llamafactory/hparams/data_args.py
+++ b/src/llamafactory/hparams/data_args.py
@@ -141,3 +141,6 @@ class DataArguments:
 
         if self.streaming and self.max_samples is not None:
             raise ValueError("`max_samples` is incompatible with `streaming`.")
+
+        if self.mask_history and self.train_on_prompt:
+            raise ValueError("`Train on the last turn only` does not support `train_on_prompt`.")


### PR DESCRIPTION
# What does this PR do?

#4878 提出的 ”仅最后一轮参与训练“ 可以满足 Distillation、Reflective Chain 等场景的需求，但其实现方法存在一个小问题：

当对话总长度超过 `cutoff_len`，会退出遍历 `encoded_pairs` 的循环（截断），则最重要的最后一段对话无法加入训练数据中，且 `label` 全为 `IGNORE_INDEX`，该条数据无意义。

针对截断问题，即在保留最后一段对话的前提下，可行的解决方案有：

1. 反向遍历 `encoded_pairs` ，新增元素从头部插入 `input_ids`和`labels`，其余逻辑不变；
2. 最大化截断后所保留的对话轮次，即删除较长的单轮对话；

PR 了采取第一种方法，以最小化改动对原代码的侵入性。



Fixes #4684

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
