### PR TITLE
fix Llama-template's system prompt bug

### DIFF
--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -320,7 +320,7 @@ def _get_jinja_template(template: "Template", tokenizer: "PreTrainedTokenizer") 
     jinja_template += "{% for message in messages %}"
     jinja_template += "{% set content = message['content'] %}"
     if isinstance(template, Llama2Template):
-        jinja_template += "{% if loop.index0 == 0 and system_message is defined %}"
+        jinja_template += "{% if system_message is defined and (loop.index0 == 0 and messages[0]['role'] != 'system' or loop.index0 == 1 and messages[0]['role'] == 'system') %}"
         jinja_template += "{% set content = " + system_message + " + message['content'] %}"
         jinja_template += "{% endif %}"
 

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -310,17 +310,18 @@ def _get_jinja_template(template: "Template", tokenizer: "PreTrainedTokenizer") 
         jinja_template += "{% set system_message = '" + _jinja_escape(template.default_system) + "' %}"
 
     jinja_template += (
-        "{% if messages[0]['role'] == 'system' %}{% set system_message = messages[0]['content'] %}{% endif %}"
+        "{% if messages[0]['role'] == 'system' %}{% set loop_messages = messages[1:] %}"
+        "{% set system_message = messages[0]['content'] %}{% else %}{% set loop_messages = messages %}{% endif %}"
     )
 
     system_message = _convert_slots_to_jinja(template.format_system.apply(), tokenizer, placeholder="system_message")
     if not isinstance(template, Llama2Template):
         jinja_template += "{% if system_message is defined %}{{ " + system_message + " }}{% endif %}"
 
-    jinja_template += "{% for message in messages %}"
+    jinja_template += "{% for message in loop_messages %}"
     jinja_template += "{% set content = message['content'] %}"
     if isinstance(template, Llama2Template):
-        jinja_template += "{% if system_message is defined and (loop.index0 == 0 and messages[0]['role'] != 'system' or loop.index0 == 1 and messages[0]['role'] == 'system') %}"
+        jinja_template += "{% if loop.index0 == 0 and system_message is defined %}"
         jinja_template += "{% set content = " + system_message + " + message['content'] %}"
         jinja_template += "{% endif %}"
 


### PR DESCRIPTION
# What does this PR do?

Llama 模型对应的 jinjia 模板有误，会导致系统提示被覆盖。

目前 Llama 的 jinjia 模板：
```jinja2
{% set system_message = '[template.default_system]' %}

{% if messages[0]['role'] == 'system' %}
    {% set system_message = messages[0]['content'] %}
{% endif %}

{% for message in messages %}
    {% set content = message['content'] %}
    
    {% if loop.index0 == 0 and system_message is defined %}
        {% set content = '<<SYS>>\n' + system_message + '\n<</SYS>>\n\n' + message['content'] %}
    {% endif %}
    
    {% if message['role'] == 'user' %}
        {{ '[INST] ' + content + ' [/INST]' }}
    {% elif message['role'] == 'assistant' %}
        {{ content + '' }}
    {% endif %}
{% endfor %}

```

该方法只能满足默认的`system_message`，用户自定义的 `system_message` 会被后一轮 user 覆盖。

为解决这一问题，修改了判断条件，自定义系统提示词时，跳过第一轮。



Fixes # (issue)

[#5123](https://github.com/hiyouga/LLaMA-Factory/issues/5123)

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
