### PR TITLE
Avoid casting model params to float32 with unsloth

### DIFF
--- a/src/llamafactory/model/adapter.py
+++ b/src/llamafactory/model/adapter.py
@@ -298,6 +298,8 @@ def init_adapter(
         logger.info("Pure bf16 / BAdam detected, remaining trainable params in half precision.")
     elif model_args.quantization_bit is None and (is_deepspeed_zero3_enabled() or is_fsdp_enabled()):
         logger.info("ZeRO3 / FSDP detected, remaining trainable params in float32.")
+    elif model_args.use_unsloth:
+        logger.info("Unsloth detected, using auto half precision backend.")
     else:
         logger.info("Upcasting trainable params to float32.")
         cast_trainable_params_to_fp32 = True


### PR DESCRIPTION
# What does this PR do?

Reduce VRAM usage during LoRA training when using Unsloth.

Fixes # (issue)

Avoid casting of model parameters to float32 when using Unsloth.

### Experimental Results:
* GPU: RTX 4060 Ti 16GB
* Model: google/gemma-2-2b-it
* Options: --use_unsloth --quantization_bit 4 --bf16 --finetuning_type lora --lora_target all -- lora_rank 128 --per_device_train_batch_size 6 --gradient_accumulation_steps 2
* Before: CUDA out of memory error
* After: No error

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
