### PR TITLE
Add SailorLLM template

### DIFF
--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -787,7 +787,10 @@ _register_template(
     format_user=StringFormatter(slots=["<|im_start|>question\n{{content}}<|im_end|>\n<|im_start|>answer\n"]),
     format_system=StringFormatter(slots=["<|im_start|>system\n{{content}}<|im_end|>\n"]),
     format_separator=EmptyFormatter(slots=["\n"]),
-    default_system="You are a helpful assistant.",
+    default_system=(
+        "You are an AI assistant named Sailor created by Sea AI Lab. "
+        "Your answer should be friendly, unbiased, faithful, informative and detailed."
+    ),
     stop_words=["<|im_end|>"],
     replace_eos=True,
 )

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -783,6 +783,17 @@ _register_template(
 
 
 _register_template(
+    name="sailor",
+    format_user=StringFormatter(slots=["<|im_start|>question\n{{content}}<|im_end|>\n<|im_start|>answer\n"]),
+    format_system=StringFormatter(slots=["<|im_start|>system\n{{content}}<|im_end|>\n"]),
+    format_separator=EmptyFormatter(slots=["\n"]),
+    default_system="You are a helpful assistant.",
+    stop_words=["<|im_end|>"],
+    replace_eos=True,
+)
+
+
+_register_template(
     name="solar",
     format_user=StringFormatter(slots=["### User:\n{{content}}\n\n### Assistant:\n"]),
     format_system=StringFormatter(slots=["### System:\n{{content}}\n\n"]),


### PR DESCRIPTION
# What does this PR do?
This PR adds a new template for SailorLLM to the repository, which enhances the system's ability to format user and system inputs according to the SailorLLM format. This template uses the following structure:

- **User Format:** `<|im_start|>question\n{{content}}<|im_end|>\n<|im_start|>answer\n`
- **System Format:** `<|im_start|>system\n{{content}}<|im_end|>\n`
- **Separator:** `\n`
- **Stop Words:** `["<|im_end|>"]`
- **Replace EOS:** `True`

This addition is based on the SailorLLM's formatting style, as referenced from the [SailorLLM repository](https://github.com/sail-sg/sailor-llm).

**SailorLLM** is a suite of Open Language Models for South-East Asia (SEA), focusing on languages like Indonesian, Thai, Vietnamese, Malay, and Lao. Built on Qwen 1.5, Sailor models range from 0.5B to 14B parameters and are fine-tuned for SEA language tasks. [Sailor models on Hugging Face](https://huggingface.co/collections/sail/sailor-language-models-65e19a749f978976f1959825). This template supports Sailor models of sizes 0.5B/1.8B/4B/7B/14B.
Fixes # (issue)

No specific issue is linked to this PR.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?