### PR TITLE
fix: report correct device count for intel xpu

### DIFF
--- a/src/llamafactory/extras/misc.py
+++ b/src/llamafactory/extras/misc.py
@@ -141,6 +141,8 @@ def get_device_count() -> int:
         return torch.npu.device_count()
     elif is_torch_cuda_available():
         return torch.cuda.device_count()
+    elif is_torch_xpu_available():
+        return torch.xpu.device_count()
     else:
         return 0
 


### PR DESCRIPTION
# What does this PR do?

Reports correct device count for Intel OneAPI devices.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?
