### PR TITLE
_is_bf16_available judgment supports npu

### DIFF
--- a/src/llamafactory/extras/misc.py
+++ b/src/llamafactory/extras/misc.py
@@ -37,7 +37,7 @@ from .logging import get_logger
 
 _is_fp16_available = is_torch_npu_available() or is_torch_cuda_available()
 try:
-    _is_bf16_available = is_torch_bf16_gpu_available()
+    _is_bf16_available = is_torch_bf16_gpu_available() or (is_torch_npu_available() and torch.npu.is_bf16_supported())
 except Exception:
     _is_bf16_available = False
 


### PR DESCRIPTION
# What does this PR do?

`transformers.utils.is_torch_bf16_gpu_available` currently only supports checking for GPU/CUDA availability, and `transformers` do not provide a similar interface for NPU. This results in `llama-factory` incorrectly determining that the device does not support NPU (such as Ascend 910B) when using NPU for inference. That is, when inferencing without specifying `infer_dtype`, it will automatically fall back to `fp16` instead of `bf16`.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
