### PR TITLE
Fix the missing modelscope dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ fire
 packaging
 pyyaml
 numpy<2.0.0
+modelscope


### PR DESCRIPTION
# What does this PR do?

Fix the missing modelscope dependency.

Fixes # (issue)

When selecting to download the model from ModelScope, an error message appears: "ImportError: Please install modelscope via `pip install modelscope -U`."

For example:

```log
root@30a7aaa46cca:/app# export USE_MODELSCOPE_HUB=1
root@30a7aaa46cca:/app# llamafactory-cli webui
Running on local URL:  http://0.0.0.0:7860

To create a public link, set `share=True` in `launch()`.
Traceback (most recent call last):
  File "/app/src/llamafactory/extras/misc.py", line 221, in try_download_model_from_ms
    from modelscope import snapshot_download
ModuleNotFoundError: No module named 'modelscope'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/gradio/queueing.py", line 575, in process_events
    response = await route_utils.call_process_api(
  File "/usr/local/lib/python3.10/dist-packages/gradio/route_utils.py", line 288, in call_process_api
    output = await app.get_blocks().process_api(
  File "/usr/local/lib/python3.10/dist-packages/gradio/blocks.py", line 1931, in process_api
    result = await self.call_function(
  File "/usr/local/lib/python3.10/dist-packages/gradio/blocks.py", line 1528, in call_function
    prediction = await utils.async_iteration(iterator)
  File "/usr/local/lib/python3.10/dist-packages/gradio/utils.py", line 671, in async_iteration
    return await iterator.__anext__()
  File "/usr/local/lib/python3.10/dist-packages/gradio/utils.py", line 664, in __anext__
    return await anyio.to_thread.run_sync(
  File "/usr/local/lib/python3.10/dist-packages/anyio/to_thread.py", line 56, in run_sync
    return await get_async_backend().run_sync_in_worker_thread(
  File "/usr/local/lib/python3.10/dist-packages/anyio/_backends/_asyncio.py", line 2177, in run_sync_in_worker_thread
    return await future
  File "/usr/local/lib/python3.10/dist-packages/anyio/_backends/_asyncio.py", line 859, in run
    result = context.run(func, *args)
  File "/usr/local/lib/python3.10/dist-packages/gradio/utils.py", line 647, in run_sync_iterator_async
    return next(iterator)
  File "/usr/local/lib/python3.10/dist-packages/gradio/utils.py", line 809, in gen_wrapper
    response = next(iterator)
  File "/app/src/llamafactory/webui/chatter.py", line 107, in load_model
    super().__init__(args)
  File "/app/src/llamafactory/chat/chat_model.py", line 44, in __init__
    self.engine: "BaseEngine" = HuggingfaceEngine(model_args, data_args, finetuning_args, generating_args)
  File "/app/src/llamafactory/chat/hf_engine.py", line 53, in __init__
    tokenizer_module = load_tokenizer(model_args)
  File "/app/src/llamafactory/model/loader.py", line 67, in load_tokenizer
    init_kwargs = _get_init_kwargs(model_args)
  File "/app/src/llamafactory/model/loader.py", line 52, in _get_init_kwargs
    model_args.model_name_or_path = try_download_model_from_ms(model_args)
  File "/app/src/llamafactory/extras/misc.py", line 226, in try_download_model_from_ms
    raise ImportError("Please install modelscope via `pip install modelscope -U`")
ImportError: Please install modelscope via `pip install modelscope -U`
```

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
