### PR TITLE
Update the ROCm version to 6.2

### DIFF
--- a/docker/docker-rocm/Dockerfile
+++ b/docker/docker-rocm/Dockerfile
@@ -1,4 +1,4 @@
-FROM hardandheavy/transformers-rocm:2.1.0
+FROM hardandheavy/transformers-rocm:2.2.0
 
 # Define environments
 ENV MAX_JOBS=4


### PR DESCRIPTION
When upgrading to the latest version of ROCm, the vLLM installation error was fixed.

Tested on AMD Radeon RX 7900 XTX.

The image is assembled without errors when setting the arguments to true
```
services:
  llamafactory:
    build:
      dockerfile: ./docker/docker-rocm/Dockerfile
      context: ../..
      args:
        INSTALL_BNB: true
        INSTALL_VLLM: true
        INSTALL_DEEPSPEED: true
        INSTALL_FLASHATTN: true
```