### PR TITLE
fix: 修复function call数据集如果 function_call 值的为不合法json，异常提示且中断训练。

### DIFF
--- a/src/llamafactory/data/formatter.py
+++ b/src/llamafactory/data/formatter.py
@@ -113,7 +113,7 @@ class FunctionFormatter(Formatter):
                 functions.append((tool_call["name"], json.dumps(tool_call["arguments"], ensure_ascii=False)))
 
         except json.JSONDecodeError:
-            raise RuntimeError("Not Valid functions Message {}".format(str([content])))
+            raise RuntimeError("Invalid JSON format in function message: {}".format(content)
 
         elements = []
         for name, arguments in functions:
@@ -141,7 +141,7 @@ class ToolFormatter(Formatter):
             tools = json.loads(content)
             return [self.tool_utils.tool_formatter(tools) if len(tools) != 0 else ""]
         except json.JSONDecodeError:
-            raise RuntimeError("Not Valid functions Message {}".format(str([content])))
+            raise RuntimeError("Invalid JSON format in tool description: {}".format(content)
 
 
     @override

--- a/src/llamafactory/data/formatter.py
+++ b/src/llamafactory/data/formatter.py
@@ -143,7 +143,6 @@ class ToolFormatter(Formatter):
         except json.JSONDecodeError:
             raise RuntimeError("Invalid JSON format in tool description: {}".format(content))
 
-
     @override
     def extract(self, content: str) -> Union[str, List["FunctionCall"]]:
         return self.tool_utils.tool_extractor(content)

--- a/src/llamafactory/data/formatter.py
+++ b/src/llamafactory/data/formatter.py
@@ -113,7 +113,7 @@ class FunctionFormatter(Formatter):
                 functions.append((tool_call["name"], json.dumps(tool_call["arguments"], ensure_ascii=False)))
 
         except json.JSONDecodeError:
-            raise RuntimeError("Invalid JSON format in function message: {}".format(content))
+            raise RuntimeError("Invalid JSON format in function message: {}".format(str([content])))  # flat string
 
         elements = []
         for name, arguments in functions:
@@ -141,7 +141,7 @@ class ToolFormatter(Formatter):
             tools = json.loads(content)
             return [self.tool_utils.tool_formatter(tools) if len(tools) != 0 else ""]
         except json.JSONDecodeError:
-            raise RuntimeError("Invalid JSON format in tool description: {}".format(content))
+            raise RuntimeError("Invalid JSON format in tool description: {}".format(str([content])))  # flat string
 
     @override
     def extract(self, content: str) -> Union[str, List["FunctionCall"]]:

--- a/src/llamafactory/data/formatter.py
+++ b/src/llamafactory/data/formatter.py
@@ -113,7 +113,7 @@ class FunctionFormatter(Formatter):
                 functions.append((tool_call["name"], json.dumps(tool_call["arguments"], ensure_ascii=False)))
 
         except json.JSONDecodeError:
-            raise RuntimeError("Invalid JSON format in function message: {}".format(content)
+            raise RuntimeError("Invalid JSON format in function message: {}".format(content))
 
         elements = []
         for name, arguments in functions:
@@ -141,7 +141,7 @@ class ToolFormatter(Formatter):
             tools = json.loads(content)
             return [self.tool_utils.tool_formatter(tools) if len(tools) != 0 else ""]
         except json.JSONDecodeError:
-            raise RuntimeError("Invalid JSON format in tool description: {}".format(content)
+            raise RuntimeError("Invalid JSON format in tool description: {}".format(content))
 
 
     @override

--- a/src/llamafactory/data/formatter.py
+++ b/src/llamafactory/data/formatter.py
@@ -113,7 +113,7 @@ class FunctionFormatter(Formatter):
                 functions.append((tool_call["name"], json.dumps(tool_call["arguments"], ensure_ascii=False)))
 
         except json.JSONDecodeError:
-            functions = []
+            raise RuntimeError("Not Valid functions Message {}".format(str([content])))
 
         elements = []
         for name, arguments in functions:
@@ -141,7 +141,8 @@ class ToolFormatter(Formatter):
             tools = json.loads(content)
             return [self.tool_utils.tool_formatter(tools) if len(tools) != 0 else ""]
         except json.JSONDecodeError:
-            return [""]
+            raise RuntimeError("Not Valid functions Message {}".format(str([content])))
+
 
     @override
     def extract(self, content: str) -> Union[str, List["FunctionCall"]]:


### PR DESCRIPTION
# What does this PR do?
functioncall数据训练的时候，如果function message的json字符串不合法，比如中间有些非法json控制字符比如换行；json.load无法加载，此时置空functions不报任何错误会让用户很疑惑，难以定位。

Fixes # (issue)
故抛出RuntimeError异常

## Before submitting

- [ x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x ] Did you write any new necessary tests?
