### PR TITLE
[data] evaluate on each dataset

### DIFF
--- a/src/llamafactory/data/loader.py
+++ b/src/llamafactory/data/loader.py
@@ -236,7 +236,7 @@ def _get_preprocessed_dataset(
     tokenizer: "PreTrainedTokenizer",
     processor: Optional["ProcessorMixin"] = None,
     is_eval: bool = False,
-) -> Optional[Union["Dataset", "IterableDataset"]]:
+) -> Optional[Union["Dataset", "IterableDataset", Dict[str, "Dataset"]]]:
     r"""
     Preprocesses the dataset, including format checking and tokenization.
     """
@@ -317,7 +317,9 @@ def get_dataset(
     # Load and preprocess dataset
     with training_args.main_process_first(desc="load dataset"):
         dataset = _get_merged_dataset(data_args.dataset, model_args, data_args, training_args, stage)
-        eval_dataset = _get_merged_dataset(data_args.eval_dataset, model_args, data_args, training_args, stage, merge=data_args.streaming)
+        eval_dataset = _get_merged_dataset(
+            data_args.eval_dataset, model_args, data_args, training_args, stage, merge=data_args.streaming
+        )
 
     with training_args.main_process_first(desc="pre-process dataset"):
         dataset = _get_preprocessed_dataset(
@@ -330,8 +332,8 @@ def get_dataset(
                 )
         else:
             eval_dataset = _get_preprocessed_dataset(
-                    eval_dataset, data_args, training_args, stage, template, tokenizer, processor, is_eval=True
-                )
+                eval_dataset, data_args, training_args, stage, template, tokenizer, processor, is_eval=True
+            )
 
         if data_args.val_size > 1e-6:
             dataset_dict = split_dataset(dataset, data_args, seed=training_args.seed)
@@ -365,7 +367,7 @@ def get_dataset(
         dataset_module = {}
         if "train" in dataset_dict:
             dataset_module["train_dataset"] = dataset_dict["train"]
-            
+
         if "validation" in dataset_dict:
             dataset_module["eval_dataset"] = dataset_dict["validation"]
 

--- a/src/llamafactory/data/loader.py
+++ b/src/llamafactory/data/loader.py
@@ -165,7 +165,7 @@ def _get_merged_dataset(
     training_args: "Seq2SeqTrainingArguments",
     stage: Literal["pt", "sft", "rm", "ppo", "kto"],
     merge: bool = True,
-) -> Optional[Union["Dataset", "IterableDataset"]]:
+) -> Optional[Union["Dataset", "IterableDataset", Dict[str, "Dataset"]]]:
     r"""
     Returns the merged datasets in the standard format.
     """
@@ -236,7 +236,7 @@ def _get_preprocessed_dataset(
     tokenizer: "PreTrainedTokenizer",
     processor: Optional["ProcessorMixin"] = None,
     is_eval: bool = False,
-) -> Optional[Union["Dataset", "IterableDataset", Dict[str, "Dataset"]]]:
+) -> Optional[Union["Dataset", "IterableDataset"]]:
     r"""
     Preprocesses the dataset, including format checking and tokenization.
     """
@@ -318,7 +318,7 @@ def get_dataset(
     with training_args.main_process_first(desc="load dataset"):
         dataset = _get_merged_dataset(data_args.dataset, model_args, data_args, training_args, stage)
         eval_dataset = _get_merged_dataset(
-            data_args.eval_dataset, model_args, data_args, training_args, stage, merge=data_args.streaming
+            data_args.eval_dataset, model_args, data_args, training_args, stage, merge=False
         )
 
     with training_args.main_process_first(desc="pre-process dataset"):
@@ -374,7 +374,7 @@ def get_dataset(
         eval_datasets_map = {}
         for key in dataset_dict.keys():
             if key.startswith("validation_"):
-                eval_datasets_map[key] = dataset_dict[key]
+                eval_datasets_map[key[len("validation_") :]] = dataset_dict[key]
 
         if len(eval_datasets_map):
             dataset_module["eval_dataset"] = eval_datasets_map

--- a/src/llamafactory/data/loader.py
+++ b/src/llamafactory/data/loader.py
@@ -180,7 +180,7 @@ def _get_merged_dataset(
         datasets[dataset_name] = _load_single_dataset(dataset_attr, model_args, data_args, training_args)
 
     if merge:
-        return merge_dataset(datasets.values(), data_args, seed=training_args.seed)
+        return merge_dataset(list(datasets.values()), data_args, seed=training_args.seed)
     else:
         return datasets
 


### PR DESCRIPTION
`If you pass a dictionary with names of datasets as keys and datasets as values, evaluate will run separate evaluations on each dataset. This can be useful to monitor how training affects other datasets or simply to get a more fine-grained evaluation`

seq2seqtrainner support eval_dataset as Dict.

# What does this PR do?

Fixes # (issue)

## Before submitting

- [ ✅ ] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ✅ ] Did you write any new necessary tests?
  - I test it in **alpacha format data**，mode **sft**, model qwen2.5-7B-Instruct ，both **single GPU** and **2 GPU using fsdp**. 
  - the loss will be print and be logged in tensorboard run logs, which can be filtered by `_loss` in your tensorboard webUI.
