### PR TITLE
feat: Long Text Fine-Tuning Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Compared to ChatGLM's [P-Tuning](https://github.com/THUDM/ChatGLM2-6B/tree/main/
 | [Falcon](https://huggingface.co/tiiuae)                           | 7B/11B/40B/180B                  | falcon    |
 | [Gemma/Gemma 2/CodeGemma](https://huggingface.co/google)          | 2B/7B/9B/27B                     | gemma     |
 | [GLM-4](https://huggingface.co/THUDM)                             | 9B                               | glm4      |
+| [LongWriter-GLM-4](https://huggingface.co/THUDM)                  | 9B                               | glm4_long |
 | [InternLM2/InternLM2.5](https://huggingface.co/internlm)          | 7B/20B                           | intern2   |
 | [Llama](https://github.com/facebookresearch/llama)                | 7B/13B/33B/65B                   | -         |
 | [Llama 2](https://huggingface.co/meta-llama)                      | 7B/13B/70B                       | llama2    |

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Compared to ChatGLM's [P-Tuning](https://github.com/THUDM/ChatGLM2-6B/tree/main/
 | [Falcon](https://huggingface.co/tiiuae)                           | 7B/11B/40B/180B                  | falcon    |
 | [Gemma/Gemma 2/CodeGemma](https://huggingface.co/google)          | 2B/7B/9B/27B                     | gemma     |
 | [GLM-4](https://huggingface.co/THUDM)                             | 9B                               | glm4      |
-| [LongWriter-GLM-4](https://huggingface.co/THUDM)                  | 9B                               | glm4_long |
+| [LongWriter-GLM-4](https://huggingface.co/THUDM)                  | 9B                               | glm4      |
 | [InternLM2/InternLM2.5](https://huggingface.co/internlm)          | 7B/20B                           | intern2   |
 | [Llama](https://github.com/facebookresearch/llama)                | 7B/13B/33B/65B                   | -         |
 | [Llama 2](https://huggingface.co/meta-llama)                      | 7B/13B/70B                       | llama2    |

--- a/README_zh.md
+++ b/README_zh.md
@@ -173,6 +173,7 @@ https://github.com/user-attachments/assets/e6ce34b0-52d5-4f3e-a830-592106c4c272
 | [Falcon](https://huggingface.co/tiiuae)                           | 7B/11B/40B/180B                  | falcon    |
 | [Gemma/Gemma 2/CodeGemma](https://huggingface.co/google)          | 2B/7B/9B/27B                     | gemma     |
 | [GLM-4](https://huggingface.co/THUDM)                             | 9B                               | glm4      |
+| [LongWriter-GLM-4](https://huggingface.co/THUDM)                  | 9B                               | glm4_long |
 | [InternLM2/InternLM2.5](https://huggingface.co/internlm)          | 7B/20B                           | intern2   |
 | [Llama](https://github.com/facebookresearch/llama)                | 7B/13B/33B/65B                   | -         |
 | [Llama 2](https://huggingface.co/meta-llama)                      | 7B/13B/70B                       | llama2    |

--- a/README_zh.md
+++ b/README_zh.md
@@ -173,7 +173,7 @@ https://github.com/user-attachments/assets/e6ce34b0-52d5-4f3e-a830-592106c4c272
 | [Falcon](https://huggingface.co/tiiuae)                           | 7B/11B/40B/180B                  | falcon    |
 | [Gemma/Gemma 2/CodeGemma](https://huggingface.co/google)          | 2B/7B/9B/27B                     | gemma     |
 | [GLM-4](https://huggingface.co/THUDM)                             | 9B                               | glm4      |
-| [LongWriter-GLM-4](https://huggingface.co/THUDM)                  | 9B                               | glm4_long |
+| [LongWriter-GLM-4](https://huggingface.co/THUDM)                  | 9B                               | glm4      |
 | [InternLM2/InternLM2.5](https://huggingface.co/internlm)          | 7B/20B                           | intern2   |
 | [Llama](https://github.com/facebookresearch/llama)                | 7B/13B/33B/65B                   | -         |
 | [Llama 2](https://huggingface.co/meta-llama)                      | 7B/13B/70B                       | llama2    |

--- a/data/dataset_info.json
+++ b/data/dataset_info.json
@@ -622,5 +622,13 @@
       "prompt": "content"
     },
     "folder": "python"
+  },
+  "nlp_paper_inst": {
+    "file_name": "nlp_paper_inst.json",
+    "columns": {
+      "prompt": "prompt", 
+      "response": "response",
+      "system": "system"
+    }
   }
 }

--- a/examples/train_lora/start_glm_train.sh
+++ b/examples/train_lora/start_glm_train.sh
@@ -1,0 +1,38 @@
+ 
+
+CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 WANDB_API_KEY=974207f7173417ef95d2ebad4cbe7f2f9668a093 llamafactory-cli train \
+    --stage sft \
+    --do_train True \
+    --model_name_or_path /mnt/ceph/develop/jiawei/model_checkpoint/LongWriter-glm4-9b-base \
+    --preprocessing_num_workers 1 \
+    --finetuning_type lora \
+    --template glm4 \
+    --flash_attn auto \
+    --dataset_dir data \
+    --dataset nlp_paper_inst \
+    --cutoff_len 21000 \
+    --learning_rate 2e-5 \
+    --num_train_epochs 1.0 \
+    --max_samples 100000 \
+    --per_device_train_batch_size 1 \
+    --gradient_accumulation_steps 2 \
+    --lr_scheduler_type cosine \
+    --max_grad_norm 1.0 \
+    --logging_steps 1 \
+    --save_steps 1 \
+    --warmup_steps 0 \
+    --warmup_ratio 0.03 \
+    --weight_decay 0.1 \
+    --optim adamw_torch \
+    --packing True \
+    --report_to wandb \
+    --run_name LongWriter-test4 \
+    --output_dir saves/LongWriter-glm4-9b-base/lora/train_2024-11-01-test4 \
+    --bf16 True \
+    --plot_loss True \
+    --ddp_timeout 180000000 \
+    --include_num_input_tokens_seen True \
+    --lora_rank 8 \
+    --lora_alpha 32 \
+    --lora_dropout 0.05 \
+    --lora_target all 

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -680,20 +680,6 @@ _register_template(
     efficient_eos=True,
 )
 
-# TODO long-eos task, need your default_system on exists dataset propert 'system' keys
-# build inputs with format `<bos> X Y <eos>`
-# but labels with format ` Y ` not `<eos>` for long-eos task
-_register_template(
-    name="glm4_long",
-    format_user=StringFormatter(slots=["<|user|>\n{{content}}"]),
-    format_assistant=StringFormatter(slots=["<|assistant|>\n{{content}}"]),
-    format_system=StringFormatter(slots=["<|system|>\n{{content}}"]),
-    format_function=FunctionFormatter(slots=[], tool_format="glm4"),
-    format_observation=StringFormatter(slots=["<|observation|>\n{{content}}<|assistant|>"]),
-    format_tools=ToolFormatter(tool_format="glm4"),
-    stop_words=["<|user|>", "<|observation|>"],
-    efficient_eos=True,
-)
 
 _register_template(
     name="intern",

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -686,14 +686,14 @@ _register_template(
 _register_template(
     name="glm4_long",
     format_user=StringFormatter(slots=["<|user|>\n{{content}}"]),
-    format_assistant=StringFormatter(slots=["<|assistant|>\n{{content}}",{"eos_token"}]),
+    format_assistant=StringFormatter(slots=["<|assistant|>\n{{content}}"]),
     format_system=StringFormatter(slots=["<|system|>\n{{content}}"]),
     format_function=FunctionFormatter(slots=[], tool_format="glm4"),
     format_observation=StringFormatter(slots=["<|observation|>\n{{content}}<|assistant|>"]),
     format_tools=ToolFormatter(tool_format="glm4"),
     stop_words=["<|user|>", "<|observation|>"],
     # default_system= "",
-    efficient_eos=False,
+    efficient_eos=True,
 )
 
 _register_template(

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -692,7 +692,6 @@ _register_template(
     format_observation=StringFormatter(slots=["<|observation|>\n{{content}}<|assistant|>"]),
     format_tools=ToolFormatter(tool_format="glm4"),
     stop_words=["<|user|>", "<|observation|>"],
-    # default_system= "",
     efficient_eos=True,
 )
 

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -680,6 +680,21 @@ _register_template(
     efficient_eos=True,
 )
 
+# TODO long-eos task, need your default_system on exists dataset propert 'system' keys
+# build inputs with format `<bos> X Y <eos>`
+# but labels with format ` Y ` not `<eos>` for long-eos task
+_register_template(
+    name="glm4_long",
+    format_user=StringFormatter(slots=["<|user|>\n{{content}}"]),
+    format_assistant=StringFormatter(slots=["<|assistant|>\n{{content}}",{"eos_token"}]),
+    format_system=StringFormatter(slots=["<|system|>\n{{content}}"]),
+    format_function=FunctionFormatter(slots=[], tool_format="glm4"),
+    format_observation=StringFormatter(slots=["<|observation|>\n{{content}}<|assistant|>"]),
+    format_tools=ToolFormatter(tool_format="glm4"),
+    stop_words=["<|user|>", "<|observation|>"],
+    # default_system= "",
+    efficient_eos=False,
+)
 
 _register_template(
     name="intern",

--- a/src/llamafactory/extras/constants.py
+++ b/src/llamafactory/extras/constants.py
@@ -585,6 +585,16 @@ register_model_group(
 
 register_model_group(
     models={
+        "LongWriter-glm4-9b": {
+            DownloadSource.DEFAULT: "THUDM/LongWriter-glm4-9b",
+        }
+    },
+    template="glm4_long",
+)
+
+
+register_model_group(
+    models={
         "InternLM-7B": {
             DownloadSource.DEFAULT: "internlm/internlm-7b",
             DownloadSource.MODELSCOPE: "Shanghai_AI_Laboratory/internlm-7b",

--- a/src/llamafactory/hparams/data_args.py
+++ b/src/llamafactory/hparams/data_args.py
@@ -45,6 +45,12 @@ class DataArguments:
         default=1024,
         metadata={"help": "The cutoff length of the tokenized inputs in the dataset."},
     )
+    pack_data_preprocess: bool = field(
+        default=False,
+        metadata={"help": """defult 'False', When pack_data_preprocess is true, cutoff_len is not used for truncating the input;
+                            instead, it checks whether the training input parameter exceeds this value.
+                            If it does, an error is raised."""},
+    )
     train_on_prompt: bool = field(
         default=False,
         metadata={"help": "Whether or not to disable the mask on the prompt."},

--- a/src/llamafactory/webui/components/train.py
+++ b/src/llamafactory/webui/components/train.py
@@ -97,6 +97,7 @@ def create_train_tab(engine: "Engine") -> Dict[str, "Component"]:
             with gr.Column():
                 packing = gr.Checkbox()
                 neat_packing = gr.Checkbox()
+                pack_data_preprocess = gr.Checkbox()
 
             with gr.Column():
                 train_on_prompt = gr.Checkbox()
@@ -119,6 +120,7 @@ def create_train_tab(engine: "Engine") -> Dict[str, "Component"]:
             optim,
             packing,
             neat_packing,
+            pack_data_preprocess,
             train_on_prompt,
             mask_history,
             resize_vocab,
@@ -137,6 +139,7 @@ def create_train_tab(engine: "Engine") -> Dict[str, "Component"]:
             optim=optim,
             packing=packing,
             neat_packing=neat_packing,
+            pack_data_preprocess=pack_data_preprocess,
             train_on_prompt=train_on_prompt,
             mask_history=mask_history,
             resize_vocab=resize_vocab,

--- a/src/llamafactory/webui/locales.py
+++ b/src/llamafactory/webui/locales.py
@@ -651,6 +651,30 @@ LOCALES = {
             "info": "패킹된 시퀀스 간의 크로스 어텐션을 피합니다.",
         },
     },
+    "pack_data_preprocess": {
+        "en": {
+            "label": "Preprocess pack data",
+            "info": """cutoff_len is not used for truncating the input;
+                    instead, it checks whether the training input parameter exceeds this value.
+                    If it does, an error is raised.""",
+        },
+        "ru": {
+            "label": "Предобработка упакованных данных",
+            "info": "избегайте перекрестного внимания между упакованными последовательностями."
+        },
+        "zh": {
+            "label": "提前打包数据",
+            "info": """cutoff_len 不用于截断输入；
+                    相反，它会检查训练输入参数是否超出此值。
+                    如果超出，则会引发错误。""",
+        },
+        "ko": {
+            "label": "데이터 전처리",
+            "info": """cutoff_len은 입력을 자르는 데 사용되지 않으며;
+                    대신, 훈련 입력 매개변수가 이 값을 초과하는지 확인합니다.
+                    초과할 경우 오류가 발생합니다."""
+        },
+    },
     "train_on_prompt": {
         "en": {
             "label": "Train on prompt",

--- a/tests/data/test_template.py
+++ b/tests/data/test_template.py
@@ -180,7 +180,7 @@ def test_glm_long_template():
         "<|assistant|>\n"
     )
     answer_str = "很高兴认识你！"
-    model_id = "/mnt/ceph/develop/jiawei/model_checkpoint/LongWriter-glm4-9b"
+    model_id = "THUDM/LongWriter-glm4-9b"
 
     tokenizer = AutoTokenizer.from_pretrained(model_id, use_fast=False, token=HF_TOKEN, trust_remote_code=True)
     content_str = tokenizer.apply_chat_template(MESSAGES, tokenize=False)


### PR DESCRIPTION
# feat: Implement pack_data_preprocess parameter and integrate with frontend

- Added `pack_data_preprocess` parameter to control input handling during training.
  - When set to `True`, it disables the use of `cutoff_len` for truncating input, raising an error if the input exceeds the specified length.
  
- Updated frontend to reflect the changes in the parameter's behavior.

- Completed training of the full `longwriter-glm4-9b` model with the new configuration.

- Included testing with the specified dataset to validate the implementation.
![7e11f651e5134363a3ed2ee75d92e04](https://github.com/user-attachments/assets/eae1e162-f073-44dc-af91-6d048f0a7c53)
![d403afb9e0e06858d7f3c281bfb4e85](https://github.com/user-attachments/assets/4634c499-f5fa-4b56-aa9d-e84437006fa4)
![b64682e344fa1b04a0bb9be3dbc2f8e](https://github.com/user-attachments/assets/c3b4dc09-a218-4fff-860f-20b164cffdea)


## Before submitting

- [ * ] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ * ] Did you write any new necessary tests?
