### PR TITLE
use rdzv backend when launch torchrun and also update docs for multi-node training

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -89,9 +89,11 @@ llamafactory-cli train examples/train_lora/llama3_lora_predict.yaml
 #### Supervised Fine-Tuning on Multiple Nodes
 
 ```bash
-FORCE_TORCHRUN=1 NNODES=2 RANK=0 MASTER_ADDR=192.168.0.1 MASTER_PORT=29500 llamafactory-cli train examples/train_lora/llama3_lora_sft.yaml
-FORCE_TORCHRUN=1 NNODES=2 RANK=1 MASTER_ADDR=192.168.0.1 MASTER_PORT=29500 llamafactory-cli train examples/train_lora/llama3_lora_sft.yaml
+FORCE_TORCHRUN=1 NNODES=2 RDZV_ID=12345 MASTER_ADDR=192.168.0.1 MASTER_PORT=29500 llamafactory-cli train examples/train_lora/llama3_lora_sft.yaml
+FORCE_TORCHRUN=1 NNODES=2 RDZV_ID=12345 MASTER_ADDR=192.168.0.1 MASTER_PORT=29500 llamafactory-cli train examples/train_lora/llama3_lora_sft.yaml
 ```
+
+`RDZV_ID` is a unique job id (shared by all nodes participating in the job), see also [note-on-rendezvous-backend](https://pytorch.org/docs/stable/elastic/run.html#note-on-rendezvous-backend).
 
 #### Supervised Fine-Tuning with DeepSpeed ZeRO-3 (Weight Sharding)
 

--- a/examples/README_zh.md
+++ b/examples/README_zh.md
@@ -89,9 +89,11 @@ llamafactory-cli train examples/train_lora/llama3_lora_predict.yaml
 #### 多机指令监督微调
 
 ```bash
-FORCE_TORCHRUN=1 NNODES=2 RANK=0 MASTER_ADDR=192.168.0.1 MASTER_PORT=29500 llamafactory-cli train examples/train_lora/llama3_lora_sft.yaml
-FORCE_TORCHRUN=1 NNODES=2 RANK=1 MASTER_ADDR=192.168.0.1 MASTER_PORT=29500 llamafactory-cli train examples/train_lora/llama3_lora_sft.yaml
+FORCE_TORCHRUN=1 NNODES=2 RDZV_ID=12345 MASTER_ADDR=192.168.0.1 MASTER_PORT=29500 llamafactory-cli train examples/train_lora/llama3_lora_sft.yaml
+FORCE_TORCHRUN=1 NNODES=2 RDZV_ID=12345 MASTER_ADDR=192.168.0.1 MASTER_PORT=29500 llamafactory-cli train examples/train_lora/llama3_lora_sft.yaml
 ```
+
+`RDZV_ID` 为多机训练的作业 ID，归属同一组训练的节点共享此 ID。参见 [note-on-rendezvous-backend](https://pytorch.org/docs/stable/elastic/run.html#note-on-rendezvous-backend)。
 
 #### 使用 DeepSpeed ZeRO-3 平均分配显存
 


### PR DESCRIPTION
1. use rdz backend when launch torchrun script according to the pytorch doc
2. update docs for multi-node training

# What does this PR do?

Fixes #5587, related #198

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
