### PR TITLE
fix support image chat api

### DIFF
--- a/src/llamafactory/api/chat.py
+++ b/src/llamafactory/api/chat.py
@@ -112,6 +112,7 @@ def _process_request(
                         image_stream = requests.get(image_url, stream=True).raw
 
                     images.append(Image.open(image_stream).convert("RGB"))
+                    input_messages.append({"role": ROLE_MAPPING[message.role], "content": input_item.text})
         else:
             input_messages.append({"role": ROLE_MAPPING[message.role], "content": message.content})
 


### PR DESCRIPTION
# fix support image chat api

Fixes # (issue)

fix bug: failed to chat with image for api, error:
File "/root/autodl-tmp/server/llama-factory/src/llamafactory/chat/hf_engine.py", line 89, in _process_args
    if IMAGE_PLACEHOLDER not in messages[0]["content"]:
IndexError: list index out of range
