### PR TITLE
Set 'torch_device' as 'cpu' when loading pretrained adapter

### DIFF
--- a/src/llamafactory/model/adapter.py
+++ b/src/llamafactory/model/adapter.py
@@ -175,6 +175,7 @@ def _setup_lora_tuning(
             "cache_dir": model_args.cache_dir,
             "revision": model_args.model_revision,
             "token": model_args.hf_hub_token,
+            "torch_device": 'cpu',
         }
 
         for adapter in adapter_to_merge:


### PR DESCRIPTION
# What does this PR do?

When loading pretrained adapter, setting 'torch_device' as 'cpu', to avoid loading adapter on rank0 for every process.

Fixes # (issue)

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
