### PR TITLE
Increase shm_size to 16GB in docker-compose.yml

### DIFF
--- a/docker/docker-cuda/docker-compose.yml
+++ b/docker/docker-cuda/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       - "8000:8000"
     ipc: host
     tty: true
+    shm_size: '16gb'
     stdin_open: true
     command: bash
     deploy:

--- a/docker/docker-npu/docker-compose.yml
+++ b/docker/docker-npu/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - "8000:8000"
     ipc: host
     tty: true
+    shm_size: '16gb'
     stdin_open: true
     command: bash
     devices:

--- a/docker/docker-rocm/docker-compose.yml
+++ b/docker/docker-rocm/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       - "8000:8000"
     ipc: host
     tty: true
+    shm_size: '16gb'
     stdin_open: true
     command: bash
     devices:


### PR DESCRIPTION
# What does this PR do?

Fixes #4316

This pull request increases the shm_size parameter in docker-compose.yml to 16GB. The goal is to enhance the LLaMA-Factory framework’s performance for large model fine-tuning tasks by providing sufficient shared memory for efficient data loading and parallel processing.

This PR also addresses the issues discussed in [[this comment](https://github.com/hiyouga/LLaMA-Factory/issues/4316#issuecomment-2466270708)](https://github.com/hiyouga/LLaMA-Factory/issues/4316#issuecomment-2466270708) regarding Shared Memory Limit error.

## Before submitting

- [x] Did you read the [[contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?