### PR TITLE
Improve error handling for missing image files in _convert_images

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,22 +9,7 @@ requires-python = ">=3.10"
 
 [project.scripts]
 llamafactory-cli = "llamafactory.cli:main"
-
-[tool.uv]
-conflicts = [
-    [
-        {extra = "aqlm" },
-        {extra = "torch-npu" },
-    ],
-    [
-        {extra = "torch-npu" },
-        {extra = "liger-kernel" },
-    ],
-    [
-        {extra = "vllm" },
-        {extra = "torch-npu" },
-    ]
-]
+lmf = "llamafactory.cli:main"
 
 [tool.ruff]
 target-version = "py38"
@@ -55,3 +40,19 @@ indent-style = "space"
 docstring-code-format = true
 skip-magic-trailing-comma = false
 line-ending = "auto"
+
+[tool.uv]
+conflicts = [
+    [
+        { extra = "torch-npu" },
+        { extra = "aqlm" },
+    ],
+    [
+        { extra = "torch-npu" },
+        { extra = "liger-kernel" },
+    ],
+    [
+        { extra = "torch-npu" },
+        { extra = "vllm" },
+    ]
+]

--- a/src/llamafactory/data/converter.py
+++ b/src/llamafactory/data/converter.py
@@ -36,23 +36,28 @@ class DatasetConverter:
     dataset_attr: "DatasetAttr"
     data_args: "DataArguments"
 
-    def _find_medias(self, inputs: Union[Any, Sequence[Any]]) -> Optional[List[Any]]:
+    def _find_medias(self, medias: Union[Any, Sequence[Any]]) -> Optional[List[Any]]:
         r"""
         Optionally concatenates media path to media dir when loading from local disk.
         """
-        if not isinstance(inputs, list):
-            inputs = [inputs]
-        elif len(inputs) == 0:
+        if not isinstance(medias, list):
+            medias = [medias]
+        elif len(medias) == 0:
             return None
         else:
-            inputs = inputs[:]
+            medias = medias[:]
 
         if self.dataset_attr.load_from in ["script", "file"]:
-            for i in range(len(inputs)):
-                if isinstance(inputs[i], str) and os.path.isfile(os.path.join(self.data_args.media_dir, inputs[i])):
-                    inputs[i] = os.path.join(self.data_args.media_dir, inputs[i])
+            for i in range(len(medias)):
+                if isinstance(medias[i], str):
+                    if os.path.isfile(os.path.join(self.data_args.media_dir, medias[i])):
+                        medias[i] = os.path.join(self.data_args.media_dir, medias[i])
+                    else:
+                        logger.warning_rank0_once(
+                            f"Media {medias[i]} does not exist in {self.data_args.media_dir}. Using original path."
+                        )
 
-        return inputs
+        return medias
 
     @abstractmethod
     def __call__(self, example: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/llamafactory/data/converter.py
+++ b/src/llamafactory/data/converter.py
@@ -41,7 +41,7 @@ class DatasetConverter:
         Optionally concatenates media path to media dir when loading from local disk.
         """
         if not isinstance(medias, list):
-            medias = [medias]
+            medias = [medias] if medias is not None else []
         elif len(medias) == 0:
             return None
         else:

--- a/src/llamafactory/data/converter.py
+++ b/src/llamafactory/data/converter.py
@@ -47,15 +47,12 @@ class DatasetConverter:
         else:
             medias = medias[:]
 
-        if self.dataset_attr.load_from in ["script", "file"]:
+        if self.dataset_attr.load_from in ["script", "file"] and isinstance(medias[0], str):
             for i in range(len(medias)):
-                if isinstance(medias[i], str):
-                    if os.path.isfile(os.path.join(self.data_args.media_dir, medias[i])):
-                        medias[i] = os.path.join(self.data_args.media_dir, medias[i])
-                    else:
-                        logger.warning_rank0_once(
-                            f"Media {medias[i]} does not exist in {self.data_args.media_dir}. Using original path."
-                        )
+                if os.path.isfile(os.path.join(self.data_args.media_dir, medias[i])):
+                    medias[i] = os.path.join(self.data_args.media_dir, medias[i])
+                else:
+                    logger.warning_rank0_once(f"Media {medias[i]} does not exist in `media_dir`. Use original path.")
 
         return medias
 


### PR DESCRIPTION
# What does this PR do?

Improve error handling for missing image files in _convert_images

- Refactor path handling logic to enhance readability.
- Log a warning when image files are not found in specified directory, maintaining the original path.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
