### PR TITLE
feat: add swanlab for experiment tracking and visualization.

### DIFF
--- a/src/llamafactory/hparams/finetuning_args.py
+++ b/src/llamafactory/hparams/finetuning_args.py
@@ -334,10 +334,6 @@ class SwanLabArguments:
         default=None,
         metadata={"help": "The API key for SwanLab."},
     )
-    swanlab_config: dict = field(
-        default={"Framework": "🦙LLaMA Factory"},
-        metadata={"help": "The configuration file for SwanLab."},
-    )
 
 
 @dataclass

--- a/src/llamafactory/hparams/finetuning_args.py
+++ b/src/llamafactory/hparams/finetuning_args.py
@@ -308,11 +308,31 @@ class BAdamArgument:
 class SwanLabArguments:
     use_swanlab: bool = field(
         default=False,
-        metadata={"help": ""},
+        metadata={"help": "Whether or not to use the SwanLab (an experiment tracking and visualization tools)."},
     )
-    swanlab_name: str = field(
+    swanlab_project: str = field(
         default="",
-        metadata={},
+        metadata={"help": "The project name in SwanLab."},
+    )
+    swanlab_workspace: str = field(
+        default="",
+        metadata={"help": "The workspace name in SwanLab."},
+    )
+    swanlab_experiment_name: str = field(
+        default="",
+        metadata={"help": "The experiment name in SwanLab."},
+    )
+    swanlab_description: str = field(
+        default="",
+        metadata={"help": "The experiment description in SwanLab."},
+    )
+    swanlab_mode: Literal["cloud", "local", "disabled"] = field(
+        default="cloud",
+        metadata={"help": "The mode of SwanLab."},
+    )
+    swanlab_api_key: str = field(
+        default="",
+        metadata={"help": "The API key for SwanLab."},
     )
 
 

--- a/src/llamafactory/hparams/finetuning_args.py
+++ b/src/llamafactory/hparams/finetuning_args.py
@@ -308,10 +308,10 @@ class BAdamArgument:
 class SwanLabArguments:
     use_swanlab: bool = field(
         default=False,
-        metadata={"help": "Whether or not to use the SwanLab (an experiment tracking and visualization tools)."},
+        metadata={"help": "Whether or not to use the SwanLab (an experiment tracking and visualization tool)."},
     )
     swanlab_project: str = field(
-        default=None,
+        default="LLaMA Factory",
         metadata={"help": "The project name in SwanLab."},
     )
     swanlab_workspace: str = field(

--- a/src/llamafactory/hparams/finetuning_args.py
+++ b/src/llamafactory/hparams/finetuning_args.py
@@ -305,7 +305,21 @@ class BAdamArgument:
 
 
 @dataclass
-class FinetuningArguments(FreezeArguments, LoraArguments, RLHFArguments, GaloreArguments, BAdamArgument):
+class SwanLabArguments:
+    use_swanlab: bool = field(
+        default=False,
+        metadata={"help": ""},
+    )
+    swanlab_name: str = field(
+        default="",
+        metadata={},
+    )
+
+
+@dataclass
+class FinetuningArguments(
+    FreezeArguments, LoraArguments, RLHFArguments, GaloreArguments, BAdamArgument, SwanLabArguments
+):
     r"""
     Arguments pertaining to which techniques we are going to fine-tuning with.
     """

--- a/src/llamafactory/hparams/finetuning_args.py
+++ b/src/llamafactory/hparams/finetuning_args.py
@@ -322,11 +322,7 @@ class SwanLabArguments:
         default=None,
         metadata={"help": "The experiment name in SwanLab."},
     )
-    swanlab_description: str = field(
-        default=None,
-        metadata={"help": "The experiment description in SwanLab."},
-    )
-    swanlab_mode: Literal["cloud", "local", "disabled"] = field(
+    swanlab_mode: Literal["cloud", "local"] = field(
         default="cloud",
         metadata={"help": "The mode of SwanLab."},
     )

--- a/src/llamafactory/hparams/finetuning_args.py
+++ b/src/llamafactory/hparams/finetuning_args.py
@@ -334,6 +334,10 @@ class SwanLabArguments:
         default=None,
         metadata={"help": "The API key for SwanLab."},
     )
+    swanlab_config: dict = field(
+        default={"Framework": "🦙LLaMA Factory"},
+        metadata={"help": "The configuration file for SwanLab."},
+    )
 
 
 @dataclass

--- a/src/llamafactory/hparams/finetuning_args.py
+++ b/src/llamafactory/hparams/finetuning_args.py
@@ -311,7 +311,7 @@ class SwanLabArguments:
         metadata={"help": "Whether or not to use the SwanLab (an experiment tracking and visualization tool)."},
     )
     swanlab_project: str = field(
-        default="LLaMA Factory",
+        default="llamafactory",
         metadata={"help": "The project name in SwanLab."},
     )
     swanlab_workspace: str = field(

--- a/src/llamafactory/hparams/finetuning_args.py
+++ b/src/llamafactory/hparams/finetuning_args.py
@@ -311,19 +311,19 @@ class SwanLabArguments:
         metadata={"help": "Whether or not to use the SwanLab (an experiment tracking and visualization tools)."},
     )
     swanlab_project: str = field(
-        default="",
+        default=None,
         metadata={"help": "The project name in SwanLab."},
     )
     swanlab_workspace: str = field(
-        default="",
+        default=None,
         metadata={"help": "The workspace name in SwanLab."},
     )
     swanlab_experiment_name: str = field(
-        default="",
+        default=None,
         metadata={"help": "The experiment name in SwanLab."},
     )
     swanlab_description: str = field(
-        default="",
+        default=None,
         metadata={"help": "The experiment description in SwanLab."},
     )
     swanlab_mode: Literal["cloud", "local", "disabled"] = field(
@@ -331,7 +331,7 @@ class SwanLabArguments:
         metadata={"help": "The mode of SwanLab."},
     )
     swanlab_api_key: str = field(
-        default="",
+        default=None,
         metadata={"help": "The API key for SwanLab."},
     )
 

--- a/src/llamafactory/train/dpo/trainer.py
+++ b/src/llamafactory/train/dpo/trainer.py
@@ -31,7 +31,7 @@ from typing_extensions import override
 from ...extras.constants import IGNORE_INDEX
 from ...extras.packages import is_transformers_version_equal_to_4_46
 from ..callbacks import PissaConvertCallback, SaveProcessorCallback
-from ..trainer_utils import create_custom_optimizer, create_custom_scheduler, get_batch_logps
+from ..trainer_utils import create_custom_optimizer, create_custom_scheduler, get_batch_logps, get_swanlab_callback
 
 
 if TYPE_CHECKING:
@@ -105,6 +105,9 @@ class CustomDPOTrainer(DPOTrainer):
 
             self.accelerator.clip_grad_norm_ = MethodType(clip_grad_norm_old_version, self.accelerator)
             self.add_callback(BAdamCallback)
+
+        if finetuning_args.use_swanlab:
+            self.add_callback(get_swanlab_callback(finetuning_args))
 
     @override
     def create_optimizer(self) -> "torch.optim.Optimizer":

--- a/src/llamafactory/train/kto/trainer.py
+++ b/src/llamafactory/train/kto/trainer.py
@@ -30,7 +30,7 @@ from typing_extensions import override
 from ...extras.constants import IGNORE_INDEX
 from ...extras.packages import is_transformers_version_equal_to_4_46
 from ..callbacks import SaveProcessorCallback
-from ..trainer_utils import create_custom_optimizer, create_custom_scheduler, get_batch_logps
+from ..trainer_utils import create_custom_optimizer, create_custom_scheduler, get_batch_logps, get_swanlab_callback
 
 
 if TYPE_CHECKING:
@@ -100,6 +100,9 @@ class CustomKTOTrainer(KTOTrainer):
 
             self.accelerator.clip_grad_norm_ = MethodType(clip_grad_norm_old_version, self.accelerator)
             self.add_callback(BAdamCallback)
+
+        if finetuning_args.use_swanlab:
+            self.add_callback(get_swanlab_callback(finetuning_args))
 
     @override
     def create_optimizer(self) -> "torch.optim.Optimizer":

--- a/src/llamafactory/train/ppo/trainer.py
+++ b/src/llamafactory/train/ppo/trainer.py
@@ -40,7 +40,7 @@ from typing_extensions import override
 from ...extras import logging
 from ...extras.misc import AverageMeter, count_parameters, get_current_device, get_logits_processor
 from ..callbacks import FixValueHeadModelCallback, SaveProcessorCallback
-from ..trainer_utils import create_custom_optimizer, create_custom_scheduler
+from ..trainer_utils import create_custom_optimizer, create_custom_scheduler, get_swanlab_callback
 from .ppo_utils import dump_layernorm, get_rewards_from_server, replace_model, restore_layernorm
 
 
@@ -185,6 +185,9 @@ class CustomPPOTrainer(PPOTrainer, Trainer):
 
             self.accelerator.clip_grad_norm_ = MethodType(clip_grad_norm_old_version, self.accelerator)
             self.add_callback(BAdamCallback)
+
+        if finetuning_args.use_swanlab:
+            self.add_callback(get_swanlab_callback(finetuning_args))
 
     def ppo_train(self, resume_from_checkpoint: Optional[str] = None) -> None:
         r"""

--- a/src/llamafactory/train/pt/trainer.py
+++ b/src/llamafactory/train/pt/trainer.py
@@ -20,7 +20,7 @@ from typing_extensions import override
 
 from ...extras.packages import is_transformers_version_equal_to_4_46, is_transformers_version_greater_than
 from ..callbacks import PissaConvertCallback, SaveProcessorCallback
-from ..trainer_utils import create_custom_optimizer, create_custom_scheduler
+from ..trainer_utils import create_custom_optimizer, create_custom_scheduler, get_swanlab_callback
 
 
 if TYPE_CHECKING:
@@ -55,6 +55,9 @@ class CustomTrainer(Trainer):
 
             self.accelerator.clip_grad_norm_ = MethodType(clip_grad_norm_old_version, self.accelerator)
             self.add_callback(BAdamCallback)
+
+        if finetuning_args.use_swanlab:
+            self.add_callback(get_swanlab_callback(finetuning_args))
 
     @override
     def create_optimizer(self) -> "torch.optim.Optimizer":

--- a/src/llamafactory/train/rm/trainer.py
+++ b/src/llamafactory/train/rm/trainer.py
@@ -27,7 +27,7 @@ from typing_extensions import override
 from ...extras import logging
 from ...extras.packages import is_transformers_version_equal_to_4_46, is_transformers_version_greater_than
 from ..callbacks import FixValueHeadModelCallback, PissaConvertCallback, SaveProcessorCallback
-from ..trainer_utils import create_custom_optimizer, create_custom_scheduler
+from ..trainer_utils import create_custom_optimizer, create_custom_scheduler, get_swanlab_callback
 
 
 if TYPE_CHECKING:
@@ -67,6 +67,9 @@ class PairwiseTrainer(Trainer):
 
             self.accelerator.clip_grad_norm_ = MethodType(clip_grad_norm_old_version, self.accelerator)
             self.add_callback(BAdamCallback)
+
+        if finetuning_args.use_swanlab:
+            self.add_callback(get_swanlab_callback(finetuning_args))
 
     @override
     def create_optimizer(self) -> "torch.optim.Optimizer":

--- a/src/llamafactory/train/sft/trainer.py
+++ b/src/llamafactory/train/sft/trainer.py
@@ -29,7 +29,7 @@ from ...extras import logging
 from ...extras.constants import IGNORE_INDEX
 from ...extras.packages import is_transformers_version_equal_to_4_46, is_transformers_version_greater_than
 from ..callbacks import PissaConvertCallback, SaveProcessorCallback
-from ..trainer_utils import create_custom_optimizer, create_custom_scheduler
+from ..trainer_utils import create_custom_optimizer, create_custom_scheduler, get_swanlab_callback
 
 
 if TYPE_CHECKING:
@@ -70,6 +70,9 @@ class CustomSeq2SeqTrainer(Seq2SeqTrainer):
 
             self.accelerator.clip_grad_norm_ = MethodType(clip_grad_norm_old_version, self.accelerator)
             self.add_callback(BAdamCallback)
+
+        if finetuning_args.use_swanlab:
+            self.add_callback(get_swanlab_callback(finetuning_args))
 
     @override
     def create_optimizer(self) -> "torch.optim.Optimizer":

--- a/src/llamafactory/train/trainer_utils.py
+++ b/src/llamafactory/train/trainer_utils.py
@@ -463,6 +463,18 @@ def get_swanlab_callback(finetuning_args: "FinetuningArguments") -> "TrainerCall
     r"""
     Gets the callback for logging to SwanLab.
     """
-    from swanlab.integration.huggingface import SwanLabCallback
+    import swanlab
+    from swanlab.integration.transformers import SwanLabCallback
+    
+    if finetuning_args.swanlab_api_key is not None:
+        swanlab.login(api_key=finetuning_args.swanlab_api_key)
 
-    return SwanLabCallback()
+    swanlab_callback = SwanLabCallback(
+        project=finetuning_args.swanlab_project,
+        workspace=finetuning_args.swanlab_workspace,
+        experiment_name=finetuning_args.swanlab_experiment_name,
+        description=finetuning_args.swanlab_description,
+        mode=finetuning_args.swanlab_mode,
+    )
+
+    return swanlab_callback

--- a/src/llamafactory/train/trainer_utils.py
+++ b/src/llamafactory/train/trainer_utils.py
@@ -473,7 +473,6 @@ def get_swanlab_callback(finetuning_args: "FinetuningArguments") -> "TrainerCall
         project=finetuning_args.swanlab_project,
         workspace=finetuning_args.swanlab_workspace,
         experiment_name=finetuning_args.swanlab_experiment_name,
-        description=finetuning_args.swanlab_description,
         mode=finetuning_args.swanlab_mode,
         config={"Framework": "🦙LLaMA Factory"},
     )

--- a/src/llamafactory/train/trainer_utils.py
+++ b/src/llamafactory/train/trainer_utils.py
@@ -40,7 +40,7 @@ if is_galore_available():
 
 
 if TYPE_CHECKING:
-    from transformers import PreTrainedModel, Seq2SeqTrainingArguments
+    from transformers import PreTrainedModel, Seq2SeqTrainingArguments, TrainerCallback
     from trl import AutoModelForCausalLMWithValueHead
 
     from ..hparams import DataArguments
@@ -457,3 +457,12 @@ def get_batch_logps(
     labels[labels == label_pad_token_id] = 0  # dummy token
     per_token_logps = torch.gather(logits.log_softmax(-1), dim=2, index=labels.unsqueeze(2)).squeeze(2)
     return (per_token_logps * loss_mask).sum(-1), loss_mask.sum(-1)
+
+
+def get_swanlab_callback(finetuning_args: "FinetuningArguments") -> "TrainerCallback":
+    r"""
+    Gets the callback for logging to SwanLab.
+    """
+    from swanlab.integration.huggingface import SwanLabCallback
+
+    return SwanLabCallback()

--- a/src/llamafactory/train/trainer_utils.py
+++ b/src/llamafactory/train/trainer_utils.py
@@ -475,6 +475,7 @@ def get_swanlab_callback(finetuning_args: "FinetuningArguments") -> "TrainerCall
         experiment_name=finetuning_args.swanlab_experiment_name,
         description=finetuning_args.swanlab_description,
         mode=finetuning_args.swanlab_mode,
+        config={"Framework": "🦙LLaMA Factory"},
     )
 
     return swanlab_callback

--- a/src/llamafactory/train/trainer_utils.py
+++ b/src/llamafactory/train/trainer_utils.py
@@ -465,7 +465,7 @@ def get_swanlab_callback(finetuning_args: "FinetuningArguments") -> "TrainerCall
     """
     import swanlab
     from swanlab.integration.transformers import SwanLabCallback
-    
+
     if finetuning_args.swanlab_api_key is not None:
         swanlab.login(api_key=finetuning_args.swanlab_api_key)
 

--- a/src/llamafactory/webui/components/train.py
+++ b/src/llamafactory/webui/components/train.py
@@ -273,7 +273,7 @@ def create_train_tab(engine: "Engine") -> Dict[str, "Component"]:
     with gr.Accordion(open=False) as swanlab_tab:
         with gr.Row():
             use_swanlab = gr.Checkbox()
-            swanlab_project = gr.Textbox(value="LLaMA-Factory", placeholder="Project name", interactive=True)
+            swanlab_project = gr.Textbox(value="llamafactory", placeholder="Project name", interactive=True)
             swanlab_experiment_name = gr.Textbox(value="", placeholder="Experiment name", interactive=True)
             swanlab_workspace = gr.Textbox(value="", placeholder="Workspace name", interactive=True)
             swanlab_api_key = gr.Textbox(value="", placeholder="API key", interactive=True)

--- a/src/llamafactory/webui/components/train.py
+++ b/src/llamafactory/webui/components/train.py
@@ -273,12 +273,12 @@ def create_train_tab(engine: "Engine") -> Dict[str, "Component"]:
     with gr.Accordion(open=False) as swanlab_tab:
         with gr.Row():
             use_swanlab = gr.Checkbox()
-            swanlab_api_key = gr.Textbox(value="", placeholder="API key", interactive=True)
-            swanlab_project = gr.Textbox(value="", placeholder="Project name", interactive=True)
-            swanlab_workspace = gr.Textbox(value="", placeholder="Workspace name", interactive=True)
+            swanlab_project = gr.Textbox(value="LLaMA-Factory", placeholder="Project name", interactive=True)
             swanlab_experiment_name = gr.Textbox(value="", placeholder="Experiment name", interactive=True)
             swanlab_description = gr.Textbox(value="", placeholder="Experiment description", interactive=True)
             swanlab_mode = gr.Dropdown(choices=["cloud", "local", "disabled"], value="cloud", interactive=True)
+            swanlab_workspace = gr.Textbox(value="", placeholder="Workspace name", interactive=True)
+            swanlab_api_key = gr.Textbox(value="", placeholder="API key", interactive=True)
 
     input_elems.update({use_swanlab, swanlab_api_key, swanlab_project, swanlab_workspace, swanlab_experiment_name, swanlab_description, swanlab_mode})
     elem_dict.update(

--- a/src/llamafactory/webui/components/train.py
+++ b/src/llamafactory/webui/components/train.py
@@ -270,6 +270,18 @@ def create_train_tab(engine: "Engine") -> Dict[str, "Component"]:
         )
     )
 
+    with gr.Accordion(open=False) as swanlab_tab:
+        with gr.Row():
+            use_swanlab = gr.Checkbox()
+
+    input_elems.update({use_swanlab})
+    elem_dict.update(
+        dict(
+            swanlab_tab=swanlab_tab,
+            use_swanlab=use_swanlab,
+        )
+    )
+
     with gr.Row():
         cmd_preview_btn = gr.Button()
         arg_save_btn = gr.Button()

--- a/src/llamafactory/webui/components/train.py
+++ b/src/llamafactory/webui/components/train.py
@@ -280,7 +280,7 @@ def create_train_tab(engine: "Engine") -> Dict[str, "Component"]:
             swanlab_description = gr.Textbox(value="", placeholder="Experiment description", interactive=True)
             swanlab_mode = gr.Dropdown(choices=["cloud", "local", "disabled"], value="cloud", interactive=True)
 
-    input_elems.update({use_swanlab})
+    input_elems.update({use_swanlab, swanlab_api_key, swanlab_project, swanlab_workspace, swanlab_experiment_name, swanlab_description, swanlab_mode})
     elem_dict.update(
         dict(
             swanlab_tab=swanlab_tab,

--- a/src/llamafactory/webui/components/train.py
+++ b/src/llamafactory/webui/components/train.py
@@ -273,12 +273,24 @@ def create_train_tab(engine: "Engine") -> Dict[str, "Component"]:
     with gr.Accordion(open=False) as swanlab_tab:
         with gr.Row():
             use_swanlab = gr.Checkbox()
+            swanlab_api_key = gr.Textbox(value="", placeholder="API key", interactive=True)
+            swanlab_project = gr.Textbox(value="", placeholder="Project name", interactive=True)
+            swanlab_workspace = gr.Textbox(value="", placeholder="Workspace name", interactive=True)
+            swanlab_experiment_name = gr.Textbox(value="", placeholder="Experiment name", interactive=True)
+            swanlab_description = gr.Textbox(value="", placeholder="Experiment description", interactive=True)
+            swanlab_mode = gr.Dropdown(choices=["cloud", "local", "disabled"], value="cloud", interactive=True)
 
     input_elems.update({use_swanlab})
     elem_dict.update(
         dict(
             swanlab_tab=swanlab_tab,
             use_swanlab=use_swanlab,
+            swanlab_api_key=swanlab_api_key,
+            swanlab_project=swanlab_project,
+            swanlab_workspace=swanlab_workspace,
+            swanlab_experiment_name=swanlab_experiment_name,
+            swanlab_description=swanlab_description,
+            swanlab_mode=swanlab_mode,
         )
     )
 

--- a/src/llamafactory/webui/components/train.py
+++ b/src/llamafactory/webui/components/train.py
@@ -275,12 +275,11 @@ def create_train_tab(engine: "Engine") -> Dict[str, "Component"]:
             use_swanlab = gr.Checkbox()
             swanlab_project = gr.Textbox(value="LLaMA-Factory", placeholder="Project name", interactive=True)
             swanlab_experiment_name = gr.Textbox(value="", placeholder="Experiment name", interactive=True)
-            swanlab_description = gr.Textbox(value="", placeholder="Experiment description", interactive=True)
-            swanlab_mode = gr.Dropdown(choices=["cloud", "local", "disabled"], value="cloud", interactive=True)
             swanlab_workspace = gr.Textbox(value="", placeholder="Workspace name", interactive=True)
             swanlab_api_key = gr.Textbox(value="", placeholder="API key", interactive=True)
+            swanlab_mode = gr.Dropdown(choices=["cloud", "local", "disabled"], value="cloud", interactive=True)
 
-    input_elems.update({use_swanlab, swanlab_api_key, swanlab_project, swanlab_workspace, swanlab_experiment_name, swanlab_description, swanlab_mode})
+    input_elems.update({use_swanlab, swanlab_api_key, swanlab_project, swanlab_workspace, swanlab_experiment_name, swanlab_mode})
     elem_dict.update(
         dict(
             swanlab_tab=swanlab_tab,
@@ -289,7 +288,6 @@ def create_train_tab(engine: "Engine") -> Dict[str, "Component"]:
             swanlab_project=swanlab_project,
             swanlab_workspace=swanlab_workspace,
             swanlab_experiment_name=swanlab_experiment_name,
-            swanlab_description=swanlab_description,
             swanlab_mode=swanlab_mode,
         )
     )

--- a/src/llamafactory/webui/locales.py
+++ b/src/llamafactory/webui/locales.py
@@ -1438,7 +1438,7 @@ LOCALES = {
     },
     "swanlab_experiment_name": {
         "en": {
-            "label": "Experiment_name(optional)",
+            "label": "Experiment name (optional)",
         },
         "ru": {
             "label": "Имя эксперимента(Необязательный)",

--- a/src/llamafactory/webui/locales.py
+++ b/src/llamafactory/webui/locales.py
@@ -1353,6 +1353,20 @@ LOCALES = {
             "info": "비율-BAdam의 업데이트 비율.",
         },
     },
+    "swanlab_tab": {
+        "en": {
+            "label": "SwanLab configurations",
+        },
+        "ru": {
+            "label": "Конфигурации SwanLab",
+        },
+        "zh": {
+            "label": "SwanLab 参数设置",
+        },
+        "ko": {
+            "label": "SwanLab 설정",
+        },
+    },
     "cmd_preview_btn": {
         "en": {
             "value": "Preview command",

--- a/src/llamafactory/webui/locales.py
+++ b/src/llamafactory/webui/locales.py
@@ -1367,6 +1367,112 @@ LOCALES = {
             "label": "SwanLab 설정",
         },
     },
+    "use_swanlab": {
+        "en": {
+            "label": "Use SwanLab",
+            "info": "Enable SwanLab for experiment tracking and visualization.",
+        },
+        "ru": {
+            "label": "Использовать SwanLab",
+            "info": "Включить SwanLab для отслеживания и визуализации экспериментов.",
+        },
+        "zh": {
+            "label": "使用 SwanLab",
+            "info": "启用 SwanLab 进行实验跟踪和可视化。",
+        },
+        "ko": {
+            "label": "SwanLab 사용",
+            "info": "SwanLab를 사용하여 실험을 추적하고 시각화합니다.",
+        },
+    },
+    "swanlab_api_key": {
+        "en": {
+            "label": "API key",
+            "info": "The API key for SwanLab.",
+        },
+        "ru": {
+            "label": "API ключ",
+            "info": "API ключ для SwanLab.",
+        },
+        "zh": {
+            "label": "API 密钥",
+            "info": "SwanLab 的 API 密钥。",
+        },
+        "ko": {
+            "label": "API 키",
+            "info": "SwanLab의 API 키.",
+        },
+    },
+    "swanlab_project": {
+        "en": {
+            "label": "SwanLab project",
+        },
+        "ru": {
+            "label": "Проект SwanLab",
+        },
+        "zh": {
+            "label": "SwanLab 项目",
+        },
+        "ko": {
+            "label": "SwanLab 프로젝트",
+        },
+    },
+    "swanlab_workspace": {
+        "en": {
+            "label": "SwanLab workspace",
+        },
+        "ru": {
+            "label": "Рабочая область SwanLab",
+        },
+        "zh": {
+            "label": "SwanLab 工作区",
+        },
+        "ko": {
+            "label": "SwanLab 작업 영역",
+        },
+    },
+    "swanlab_experiment_name": {
+        "en": {
+            "label": "SwanLab experiment name",
+        },
+        "ru": {
+            "label": "Имя эксперимента SwanLab",
+        },
+        "zh": {
+            "label": "SwanLab 实验名称",
+        },
+        "ko": {
+            "label": "SwanLab 실험 이름",
+        },
+    },
+    "swanlab_description": {
+        "en": {
+            "label": "SwanLab experiment description",
+        },
+        "ru": {
+            "label": "Описание эксперимента SwanLab",
+        },
+        "zh": {
+            "label": "SwanLab 实验描述",
+        },
+        "ko": {
+            "label": "SwanLab 실험 설명",
+        },
+    },
+    "swanlab_mode": {
+        "en": {
+            "label": "SwanLab mode",
+        },
+        "ru": {
+            "label": "Режим SwanLab",
+        },
+        "zh": {
+            "label": "SwanLab 模式",
+        },
+        "ko": {
+            "label": "SwanLab 모드",
+        },
+    },
     "cmd_preview_btn": {
         "en": {
             "value": "Preview command",

--- a/src/llamafactory/webui/locales.py
+++ b/src/llamafactory/webui/locales.py
@@ -1387,90 +1387,85 @@ LOCALES = {
     },
     "swanlab_api_key": {
         "en": {
-            "label": "API key",
-            "info": "The API key for SwanLab.",
+            "label": "API Key(optional)",
+            "info": "API key for SwanLab. Once logged in, no need to login again in the programming environment.",
         },
         "ru": {
-            "label": "API ключ",
-            "info": "API ключ для SwanLab.",
+            "label": "API ключ(Необязательный)",
+            "info": "API ключ для SwanLab. После входа в программное окружение, нет необходимости входить снова.",
         },
         "zh": {
-            "label": "API 密钥",
-            "info": "SwanLab 的 API 密钥。",
+            "label": "API密钥(选填)",
+            "info": "用于在编程环境登录SwanLab，已登录则无需填写。",
         },
         "ko": {
-            "label": "API 키",
-            "info": "SwanLab의 API 키.",
+            "label": "API 키(선택 사항)",
+            "info": "SwanLab의 API 키. 프로그래밍 환경에 로그인한 후 다시 로그인할 필요가 없습니다.",
         },
     },
     "swanlab_project": {
         "en": {
-            "label": "SwanLab project",
+            "label": "Project(optional)",
         },
         "ru": {
-            "label": "Проект SwanLab",
+            "label": "Проект(Необязательный)",
         },
         "zh": {
-            "label": "SwanLab 项目",
+            "label": "项目(选填)",
         },
         "ko": {
-            "label": "SwanLab 프로젝트",
+            "label": "프로젝트(선택 사항)",
         },
     },
     "swanlab_workspace": {
         "en": {
-            "label": "SwanLab workspace",
+            "label": "Workspace(optional)",
+            "info": "Workspace for SwanLab. If not filled, it defaults to the personal workspace.",
+            
         },
         "ru": {
-            "label": "Рабочая область SwanLab",
+            "label": "Рабочая область(Необязательный)",
+            "info": "Рабочая область SwanLab, если не заполнено, то по умолчанию в личной рабочей области.",
         },
         "zh": {
-            "label": "SwanLab 工作区",
+            "label": "Workspace(选填)",
+            "info": "SwanLab组织的工作区，如不填写则默认在个人工作区下",
         },
         "ko": {
-            "label": "SwanLab 작업 영역",
+            "label": "작업 영역(선택 사항)",
+            "info": "SwanLab 조직의 작업 영역, 비어 있으면 기본적으로 개인 작업 영역에 있습니다.",
         },
     },
     "swanlab_experiment_name": {
         "en": {
-            "label": "SwanLab experiment name",
+            "label": "Experiment_name(optional)",
         },
         "ru": {
-            "label": "Имя эксперимента SwanLab",
+            "label": "Имя эксперимента(Необязательный)",
         },
         "zh": {
-            "label": "SwanLab 实验名称",
+            "label": "实验名(选填)  ",
         },
         "ko": {
-            "label": "SwanLab 실험 이름",
-        },
-    },
-    "swanlab_description": {
-        "en": {
-            "label": "SwanLab experiment description",
-        },
-        "ru": {
-            "label": "Описание эксперимента SwanLab",
-        },
-        "zh": {
-            "label": "SwanLab 实验描述",
-        },
-        "ko": {
-            "label": "SwanLab 실험 설명",
+            "label": "실험 이름(선택 사항)",
         },
     },
     "swanlab_mode": {
         "en": {
-            "label": "SwanLab mode",
+            "label": "Mode",
+            "info": "Cloud or offline version.",    
         },
         "ru": {
-            "label": "Режим SwanLab",
+            "label": "Режим",
+            "info": "Версия в облаке или локальная версия.",
         },
         "zh": {
-            "label": "SwanLab 模式",
+            "label": "模式",
+            "info": "云端版或离线版",
         },
         "ko": {
-            "label": "SwanLab 모드",
+            "label": "모드",
+            "info": "클라우드 버전 또는 오프라인 버전.",
         },
     },
     "cmd_preview_btn": {

--- a/src/llamafactory/webui/runner.py
+++ b/src/llamafactory/webui/runner.py
@@ -231,7 +231,13 @@ class Runner:
 
         # swanlab config
         if get("train.use_swanlab"):
-            args["swanlab_name"] = get("train.swanlab_name")
+            args["swanlab_api_key"] = get("train.swanlab_api_key")
+            args["swanlab_project"] = get("train.swanlab_project")
+            args["swanlab_workspace"] = get("train.swanlab_workspace")
+            args["swanlab_experiment_name"] = get("train.swanlab_experiment_name")
+            args["swanlab_description"] = get("train.swanlab_description")
+            args["swanlab_mode"] = get("train.swanlab_mode")
+            
 
         # eval config
         if get("train.val_size") > 1e-6 and args["stage"] != "ppo":

--- a/src/llamafactory/webui/runner.py
+++ b/src/llamafactory/webui/runner.py
@@ -235,7 +235,6 @@ class Runner:
             args["swanlab_project"] = get("train.swanlab_project")
             args["swanlab_workspace"] = get("train.swanlab_workspace")
             args["swanlab_experiment_name"] = get("train.swanlab_experiment_name")
-            args["swanlab_description"] = get("train.swanlab_description")
             args["swanlab_mode"] = get("train.swanlab_mode")
             
 

--- a/src/llamafactory/webui/runner.py
+++ b/src/llamafactory/webui/runner.py
@@ -147,6 +147,7 @@ class Runner:
             report_to="all" if get("train.report_to") else "none",
             use_galore=get("train.use_galore"),
             use_badam=get("train.use_badam"),
+            use_swanlab=get("train.use_swanlab"),
             output_dir=get_save_dir(model_name, finetuning_type, get("train.output_dir")),
             fp16=(get("train.compute_type") == "fp16"),
             bf16=(get("train.compute_type") == "bf16"),
@@ -227,6 +228,10 @@ class Runner:
             args["badam_switch_mode"] = get("train.badam_switch_mode")
             args["badam_switch_interval"] = get("train.badam_switch_interval")
             args["badam_update_ratio"] = get("train.badam_update_ratio")
+
+        # swanlab config
+        if get("train.use_swanlab"):
+            args["swanlab_name"] = get("train.swanlab_name")
 
         # eval config
         if get("train.val_size") > 1e-6 and args["stage"] != "ppo":


### PR DESCRIPTION
## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?

## 如何在LLaMA Factory中使用SwanLab?

[SwanLab](https://github.com/swanhubx/swanlab) 是一个开源的模型训练记录工具，面向AI研究者，提供了训练可视化、自动日志记录、超参数记录、实验对比、多人协同等功能。在SwanLab上，研究者能基于直观的可视化图表发现训练问题，对比多个实验找到研究灵感，并通过在线链接的分享与基于组织的多人协同训练，打破团队沟通的壁垒。

**为什么要记录训练**

相较于软件开发，模型训练更像一个实验科学。一个品质优秀的模型背后，往往是成千上万次实验。研究者需要不断尝试、记录、对比，积累经验，才能找到最佳的模型结构、超参数与数据配比。在这之中，如何高效进行记录与对比，对于研究效率的提升至关重要。

**在LLaMA Factory中使用**

**方式一：CLI**

在yaml配置文件中，增加如下代码（注释的部分，代表选填）：

```yaml
## swanlab
use_swanlab: true
swanlab_project: LLaMA-Factory
# swanlab_experiment_name: qwen2-vl-2b-lora-sft
# swanlab_workspace: your_organization_username
# swanlab_mode: cloud
# swanlab_api_key: your_api_key
```

然后CLI启动命令即可：

```bash
llamafactory-cli train your_config.yaml
```

**方式二：WebUI**

启动WebUI：
```bash
llamafactory-cli webui
```

<img width="1539" alt="image" src="https://github.com/user-attachments/assets/2de87d1e-2866-4992-8a5e-95bee946e077" />

在GUI中对应栏位填写参数后，启动训练后，在系统的命令行打印中找到SwanLab实验链接访问即可：

<img width="1070" alt="image" src="https://github.com/user-attachments/assets/1405d576-47cd-4a2e-a76e-5dce598b7d4f" />


## 备注

**SwanLab API Key如何获取**

在[官网](https://swanlab.cn)或[备用官网](https://swanlab.115.zone)注册/登录账号，在设置中找到API Key。
如果你使用local模式，则无需 API Key。

**一些交互上的想法**

如果在「SwanLab 参数设置」选项卡中，能够增加一个按钮，点击跳转到对应的SwanLab链接，那用户体验就更好了：），暂时在开发上不知道要怎么写。

获取链接的代码：

```python
import swanlab

run = swanlab.init()

print(run.public.json()["cloud"]["experiment_url"])
```





