### PR TITLE
Add ARG HTTP_PROXY in Dockerfile to support HTTP proxy during image building

### DIFF
--- a/docker/docker-cuda/Dockerfile
+++ b/docker/docker-cuda/Dockerfile
@@ -22,6 +22,7 @@ ARG HTTP_PROXY=
 # Set the working directory
 WORKDIR /app
 
+# Set http proxy
 RUN if [ -n "$HTTP_PROXY" ]; then \  
         echo "Configuring proxy..."; \  
         export http_proxy=$HTTP_PROXY; \  
@@ -82,6 +83,7 @@ RUN pip uninstall -y transformer-engine flash-attn && \
     fi
 
 
+# Unset http proxy
 RUN if [ -n "$HTTP_PROXY" ]; then \
         unset http_proxy; \
         unset https_proxy; \

--- a/docker/docker-cuda/Dockerfile
+++ b/docker/docker-cuda/Dockerfile
@@ -17,16 +17,27 @@ ARG INSTALL_LIGER_KERNEL=false
 ARG INSTALL_HQQ=false
 ARG INSTALL_EETQ=false
 ARG PIP_INDEX=https://pypi.org/simple
+ARG HTTP_PROXY=
 
 # Set the working directory
 WORKDIR /app
+
+RUN if [ -n "$HTTP_PROXY" ]; then \  
+        echo "Configuring proxy..."; \  
+        export http_proxy=$HTTP_PROXY; \  
+        export https_proxy=$HTTP_PROXY; \  
+    fi
 
 # Install the requirements
 COPY requirements.txt /app
 RUN pip config set global.index-url "$PIP_INDEX" && \
     pip config set global.extra-index-url "$PIP_INDEX" && \
     python -m pip install --upgrade pip && \
-    python -m pip install -r requirements.txt
+    if [ -n "$HTTP_PROXY" ]; then \  
+        python -m pip install --proxy=$HTTP_PROXY -r requirements.txt; \  
+    else \  
+        python -m pip install -r requirements.txt; \  
+    fi
 
 # Copy the rest of the application into the image
 COPY . /app
@@ -51,13 +62,29 @@ RUN EXTRA_PACKAGES="metrics"; \
     if [ "$INSTALL_EETQ" == "true" ]; then \
         EXTRA_PACKAGES="${EXTRA_PACKAGES},eetq"; \
     fi; \
-    pip install -e ".[$EXTRA_PACKAGES]"
+    if [ -n "$HTTP_PROXY" ]; then \  
+        pip install --proxy=$HTTP_PROXY -e ".[$EXTRA_PACKAGES]"; \  
+    else \  
+        pip install -e ".[$EXTRA_PACKAGES]"; \  
+    fi
 
 # Rebuild flash attention
 RUN pip uninstall -y transformer-engine flash-attn && \
     if [ "$INSTALL_FLASHATTN" == "true" ]; then \
-        pip uninstall -y ninja && pip install ninja && \
-        pip install --no-cache-dir flash-attn --no-build-isolation; \
+        pip uninstall -y ninja && \
+        if [ -n "$HTTP_PROXY" ]; then \
+            pip install --proxy=$HTTP_PROXY ninja && \
+            pip install --proxy=$HTTP_PROXY --no-cache-dir flash-attn --no-build-isolation; \
+        else \  
+            pip install ninja && \  
+            pip install --no-cache-dir flash-attn --no-build-isolation; \
+        fi; \
+    fi
+
+
+RUN if [ -n "$HTTP_PROXY" ]; then \
+        unset http_proxy; \
+        unset https_proxy; \
     fi
 
 # Set up volumes

--- a/docker/docker-npu/Dockerfile
+++ b/docker/docker-npu/Dockerfile
@@ -12,16 +12,28 @@ ENV DEBIAN_FRONTEND=noninteractive
 ARG INSTALL_DEEPSPEED=false
 ARG PIP_INDEX=https://pypi.org/simple
 ARG TORCH_INDEX=https://download.pytorch.org/whl/cpu
+ARG HTTP_PROXY=
 
 # Set the working directory
 WORKDIR /app
+
+# Set http proxy
+RUN if [ -n "$HTTP_PROXY" ]; then \  
+        echo "Configuring proxy..."; \  
+        export http_proxy=$HTTP_PROXY; \  
+        export https_proxy=$HTTP_PROXY; \  
+    fi
 
 # Install the requirements
 COPY requirements.txt /app
 RUN pip config set global.index-url "$PIP_INDEX" && \
     pip config set global.extra-index-url "$TORCH_INDEX" && \
     python -m pip install --upgrade pip && \
-    python -m pip install -r requirements.txt
+    if [ -n "$HTTP_PROXY" ]; then \  
+        python -m pip install --proxy=$HTTP_PROXY -r requirements.txt; \  
+    else \  
+        python -m pip install -r requirements.txt; \  
+    fi
 
 # Copy the rest of the application into the image
 COPY . /app
@@ -31,7 +43,17 @@ RUN EXTRA_PACKAGES="torch-npu,metrics"; \
     if [ "$INSTALL_DEEPSPEED" == "true" ]; then \
         EXTRA_PACKAGES="${EXTRA_PACKAGES},deepspeed"; \
     fi; \
-    pip install -e ".[$EXTRA_PACKAGES]"
+    if [ -n "$HTTP_PROXY" ]; then \  
+        pip install --proxy=$HTTP_PROXY -e ".[$EXTRA_PACKAGES]"; \  
+    else \  
+        pip install -e ".[$EXTRA_PACKAGES]"; \  
+    fi
+
+# Unset http proxy
+RUN if [ -n "$HTTP_PROXY" ]; then \
+        unset http_proxy; \
+        unset https_proxy; \
+    fi
 
 # Set up volumes
 VOLUME [ "/root/.cache/huggingface", "/root/.cache/modelscope", "/app/data", "/app/output" ]

--- a/docker/docker-rocm/Dockerfile
+++ b/docker/docker-rocm/Dockerfile
@@ -13,16 +13,28 @@ ARG INSTALL_FLASHATTN=false
 ARG INSTALL_LIGER_KERNEL=false
 ARG INSTALL_HQQ=false
 ARG PIP_INDEX=https://pypi.org/simple
+ARG HTTP_PROXY=
 
 # Set the working directory
 WORKDIR /app
+
+# Set http proxy
+RUN if [ -n "$HTTP_PROXY" ]; then \  
+        echo "Configuring proxy..."; \  
+        export http_proxy=$HTTP_PROXY; \  
+        export https_proxy=$HTTP_PROXY; \  
+    fi
 
 # Install the requirements
 COPY requirements.txt /app
 RUN pip config set global.index-url "$PIP_INDEX" && \
     pip config set global.extra-index-url "$PIP_INDEX" && \
     python -m pip install --upgrade pip && \
-    python -m pip install -r requirements.txt
+    if [ -n "$HTTP_PROXY" ]; then \  
+        python -m pip install --proxy=$HTTP_PROXY -r requirements.txt; \  
+    else \  
+        python -m pip install -r requirements.txt; \  
+    fi
 
 # Copy the rest of the application into the image
 COPY . /app
@@ -44,13 +56,29 @@ RUN EXTRA_PACKAGES="metrics"; \
     if [ "$INSTALL_HQQ" == "true" ]; then \
         EXTRA_PACKAGES="${EXTRA_PACKAGES},hqq"; \
     fi; \
-    pip install -e ".[$EXTRA_PACKAGES]"
+    if [ -n "$HTTP_PROXY" ]; then \  
+        pip install --proxy=$HTTP_PROXY -e ".[$EXTRA_PACKAGES]"; \  
+    else \  
+        pip install -e ".[$EXTRA_PACKAGES]"; \  
+    fi
 
 # Rebuild flash attention
 RUN pip uninstall -y transformer-engine flash-attn && \
     if [ "$INSTALL_FLASHATTN" == "true" ]; then \
-        pip uninstall -y ninja && pip install ninja && \
-        pip install --no-cache-dir flash-attn --no-build-isolation; \
+        pip uninstall -y ninja && \
+        if [ -n "$HTTP_PROXY" ]; then \
+            pip install --proxy=$HTTP_PROXY ninja && \
+            pip install --proxy=$HTTP_PROXY --no-cache-dir flash-attn --no-build-isolation; \
+        else \  
+            pip install ninja && \  
+            pip install --no-cache-dir flash-attn --no-build-isolation; \
+        fi; \
+    fi
+
+# Unset http proxy
+RUN if [ -n "$HTTP_PROXY" ]; then \
+        unset http_proxy; \
+        unset https_proxy; \
     fi
 
 # Set up volumes


### PR DESCRIPTION
Add ARG HTTP_PROXY in Dockerfile to support HTTP proxy during image building.


This commit introduces an ARG parameter named HTTP_PROXY in the Dockerfile. This addition allows for the configuration of an HTTP proxy, facilitating image building in environments with network restrictions.  


# What does this PR do?

Fixes # (issue)

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
