### PR TITLE
Fix ray

### DIFF
--- a/src/llamafactory/hparams/parser.py
+++ b/src/llamafactory/hparams/parser.py
@@ -76,7 +76,7 @@ def _parse_args(
 
     (*parsed_args, unknown_args) = parser.parse_args_into_dataclasses(args=args, return_remaining_strings=True)
 
-    if unknown_args:
+    if unknown_args and not allow_extra_keys:
         print(parser.format_help())
         print(f"Got unknown args, potentially deprecated arguments: {unknown_args}")
         raise ValueError(f"Some specified arguments are not used by the HfArgumentParser: {unknown_args}")


### PR DESCRIPTION
# What does this PR do?
fix get_ray_args when args not a dict 

## Before submitting
when I train model not using a yaml or a json config,the args may not be a dict

![image](https://github.com/user-attachments/assets/83044ba3-206e-44dd-acf9-7b20fb6981fa)

 so get_ray_args function may raise error
![image](https://github.com/user-attachments/assets/834951ae-266b-4794-8f44-76d8c317b2d3)
because allow_extral_key is valid only when args is a dictionary.
![image](https://github.com/user-attachments/assets/8796a375-b1c7-483a-ae8d-eda13d493bec)

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?
