### PR TITLE
Update tokenizer.model_max_length if necessary (Fix #6415)

### DIFF
--- a/src/llamafactory/model/loader.py
+++ b/src/llamafactory/model/loader.py
@@ -85,6 +85,9 @@ def load_tokenizer(model_args: "ModelArguments") -> "TokenizerModule":
         )
     except Exception as e:
         raise OSError("Failed to load tokenizer.") from e
+        
+    if model_args.model_max_length is not None and tokenizer.model_max_length != model_args.model_max_length:
+        tokenizer.model_max_length = model_args.model_max_length
 
     if model_args.new_special_tokens is not None:
         num_added_tokens = tokenizer.add_special_tokens(


### PR DESCRIPTION
# What does this PR do?

Fixes #6415


It modifies logic of `loader.py -> load_tokenizer(...)` to update `tokenizer.model_max_length` if `model_args.model_max_length` changes.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?
