### PR TITLE
fix: avoid redundant normalization in DPO's SFT loss calculation

### DIFF
--- a/src/llamafactory/train/dpo/trainer.py
+++ b/src/llamafactory/train/dpo/trainer.py
@@ -204,7 +204,11 @@ class CustomDPOTrainer(DPOTrainer):
         chosen_logps, rejected_logps = all_logps.split(batch_size, dim=0)
         chosen_logits, rejected_logits = all_logits.split(batch_size, dim=0)
         chosen_length, _ = valid_length.split(batch_size, dim=0)
-        return chosen_logps, rejected_logps, chosen_logits, rejected_logits, chosen_logps / chosen_length
+
+        if self.loss_type in ["ipo", "orpo", "simpo"]:
+            return chosen_logps, rejected_logps, chosen_logits, rejected_logits, chosen_logps
+        else:
+            return chosen_logps, rejected_logps, chosen_logits, rejected_logits, chosen_logps / chosen_length
 
     @override
     def compute_reference_log_probs(


### PR DESCRIPTION
Fix: Avoid Redundant Normalization in DPO's SFT Loss Calculation
Problem
In the current implementation, the SFT loss in DPO is computed as chosen_logps / chosen_length. However, for specific loss types such as ["ipo", "orpo", "simpo"], the all_logps tensor is already normalized by dividing it by valid_length earlier in the code. When chosen_logps is further divided by chosen_length in the return statement, it results in redundant normalization, which leads to incorrect results.

Solution
This PR introduces a conditional check in the return statement to handle this case:

For ["ipo", "orpo", "simpo"]: The already normalized chosen_logps is returned directly without further division.
For all other loss types (e.g., DPO): The original behavior is preserved, and chosen_logps / chosen_length is returned to correctly compute the SFT loss.
Changes
Added a conditional check in the return statement to ensure normalization is skipped for ["ipo", "orpo", "simpo"].
Updated the function comments to reflect the adjusted logic.
Impact
Fixes a potential bug where redundant normalization could lead to incorrect outputs for ["ipo", "orpo", "simpo"].
Ensures the correct computation of the SFT loss in the DPO context for all other cases.
Testing