### PR TITLE
docs: 修正 Windows 平台上 FA2 的安装说明 

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,7 +441,7 @@ pip install https://github.com/jllllll/bitsandbytes-windows-webui/releases/downl
 
 #### Install Flash Attention-2
 
-To enable FlashAttention-2 on the Windows platform, you need to install the precompiled `flash-attn` library, which supports CUDA 12.1 to 12.2. Please download the corresponding version from [flash-attention](https://github.com/bdashore3/flash-attention/releases) based on your requirements.
+To enable FlashAttention-2 on the Windows platform, please use the script from [flash-attention-windows-wheel](https://huggingface.co/lldacing/flash-attention-windows-wheel) to compile and install it by yourself.
 
 </details>
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -443,7 +443,7 @@ pip install https://github.com/jllllll/bitsandbytes-windows-webui/releases/downl
 
 #### 安装 Flash Attention-2
 
-如果要在 Windows 平台上开启 FlashAttention-2，需要安装预编译的 `flash-attn` 库，支持 CUDA 12.1 到 12.2，请根据需求到 [flash-attention](https://github.com/bdashore3/flash-attention/releases) 下载对应版本安装。
+如果要在 Windows 平台上开启 FlashAttention-2，请使用 [flash-attention-windows-wheel](https://huggingface.co/lldacing/flash-attention-windows-wheel) 中的脚本自行编译与安装。
 
 </details>
 


### PR DESCRIPTION
# What does this PR do?

Fixes #6092

这一类的问题大概都是这个原因，印象中在 issue 看到过好几次

原始连接中的预编译版本 FA2 只支持推理，不支持训练，用于训练就会导致上面的问题

应该已经持续了有一段时间了，至少好几个月，很奇怪为什么没人指出来，我自己也是花了很久才发现问题之所在

而且因为 [LLaMA-Factory](https://github.com/hiyouga/LLaMA-Factory) 的知名度，已经开始扩散到其他场景了，在其他项目的 issue 下也看到了类似问题，反应是按照 [LLaMA-Factory](https://github.com/hiyouga/LLaMA-Factory) 的文档安装的 FA2

不过 FA2 编译的还是挺慢的，建议作者自己维护几个常用的预编译版本组合，应该可以减少处理相关 issue 的时间


## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
