### PR TITLE
Update QWEN_TOOL_PROMPT 

### DIFF
--- a/src/llamafactory/data/tool_utils.py
+++ b/src/llamafactory/data/tool_utils.py
@@ -56,7 +56,7 @@ QWEN_TOOL_PROMPT = (
     "You are provided with function signatures within <tools></tools> XML tags:\n<tools>{tool_text}"
     "\n</tools>\n\nFor each function call, return a json object with function name and arguments within "
     """<tool_call></tool_call> XML tags:\n<tool_call>\n{{"name": <function-name>, """
-    """"arguments": <args-json-object>}}\n</tool_call><|im_end|>\n"""
+    """"arguments": <args-json-object>}}\n</tool_call>"""
 )
 
 

--- a/tests/data/test_formatter.py
+++ b/tests/data/test_formatter.py
@@ -224,7 +224,7 @@ def test_qwen_tool_formatter():
         f"\n{json.dumps(wrapped_tool, ensure_ascii=False)}"
         "\n</tools>\n\nFor each function call, return a json object with function name and arguments within "
         """<tool_call></tool_call> XML tags:\n<tool_call>\n{"name": <function-name>, """
-        """"arguments": <args-json-object>}\n</tool_call><|im_end|>\n"""
+        """"arguments": <args-json-object>}\n</tool_call>"""
     ]
 
 


### PR DESCRIPTION
# What does this PR do?
Modify QWEN_TOOL_PROMPT to have aligned format with hf apply chat template.
Currently, the qwen template output does not align with the hf apply chat template output when tools are included. Specifically, `QWEN_TOOL_PROMPT` in `LLaMA-Factory/src/llamafactory/data/tool_utils.py contains` `<|im_end|>\n` at the end, and `self.format_system` in `LLaMA-Factory/src/llamafactory/data/template.py` will add another `<|im_end|>\n` to the end of the formatted system prompt, causing there to be two sets of `<|im_end|>\n` in the system prompt when using tools.

Fixes # (issue)
N/A
## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [] Did you write any new necessary tests?
