### PR TITLE
Allow thought in function call

### DIFF
--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -129,9 +129,9 @@ class Template:
             elif message["role"] == Role.OBSERVATION.value:
                 elements += self.format_observation.apply(content=message["content"])
             elif message["role"] == Role.FUNCTION.value:
-                # If 'FUNCTION_CALL: \n' is included in the message content, then extract thought and function call
-                thoughts = message["content"].split('FUNCTION_CALL: \n')[0]
-                function_call = '\n'.join(message["content"].split('FUNCTION_CALL: \n')[1:])
+                # If '<FUNCTION_CALL>: \n' is included in the message content, then extract thought and function call
+                thoughts = message["content"].split('<FUNCTION_CALL>: \n')[0]
+                function_call = '\n'.join(message["content"].split('<FUNCTION_CALL>: \n')[1:])
                 content_elements = self.format_assistant.apply(content=thoughts)
                 # pop the redundant eos_token
                 eos_idx = content_elements.index({'eos_token'})

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -129,7 +129,16 @@ class Template:
             elif message["role"] == Role.OBSERVATION.value:
                 elements += self.format_observation.apply(content=message["content"])
             elif message["role"] == Role.FUNCTION.value:
-                elements += self.format_function.apply(content=message["content"])
+                # If 'FUNCTION_CALL: \n' is included in the message content, then extract thought and function call
+                thoughts = message["content"].split('FUNCTION_CALL: \n')[0]
+                function_call = '\n'.join(message["content"].split('FUNCTION_CALL: \n')[1:])
+                content_elements = self.format_assistant.apply(content=thoughts)
+                # pop the redundant eos_token
+                eos_idx = content_elements.index({'eos_token'})
+                content_elements.pop(eos_idx)
+                function_elements = self.format_function.apply(content=function_call)
+                # combine thoughts and function call
+                elements += content_elements + function_elements
             else:
                 raise NotImplementedError("Unexpected role: {}".format(message["role"]))
 


### PR DESCRIPTION
# What does this PR do?
Add code to allow thoughts in function calling, while maintaining the same format with the huggingface apply_chat_template function. In the training data, people would need to add a special token '<FUNCTION_CALL>: \n' to separate thoughts and function calls.

Fixes # (issue)

## Before submitting

- [ ] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?
