### PR TITLE
map dataset_attr.prompt,i.e.,alpaca instruction,to system prompt

### DIFF
--- a/src/llamafactory/data/aligner.py
+++ b/src/llamafactory/data/aligner.py
@@ -69,9 +69,6 @@ def convert_alpaca(
             prompt.append({"role": Role.ASSISTANT.value, "content": old_response})
 
     query = []
-    if dataset_attr.prompt and example[dataset_attr.prompt]:
-        query.append(example[dataset_attr.prompt])
-
     if dataset_attr.query and example[dataset_attr.query]:
         query.append(example[dataset_attr.query])
 
@@ -101,7 +98,7 @@ def convert_alpaca(
     output = {
         "_prompt": prompt,
         "_response": response,
-        "_system": example[dataset_attr.system] if dataset_attr.system else "",
+        "_system": example[dataset_attr.prompt] if dataset_attr.prompt else "",
         "_tools": example[dataset_attr.tools] if dataset_attr.tools else "",
         "_images": regularize_medias(example[dataset_attr.images]) if dataset_attr.images else None,
         "_videos": regularize_medias(example[dataset_attr.videos]) if dataset_attr.videos else None,


### PR DESCRIPTION
# What does this PR do?

Currently, when parsing an alpaca dataset to the llama3 format, the `"instruction"` from the dataset gets concatenated with the `"input"` and the merged string will be inserted in the `<|start_header_id|>user<|end_header_id|>` part of the llama3 template.
With this PR, `"instruction"` from the dataset will be mapped to the `<|begin_of_text|><|start_header_id|>system<|end_header_id|>` part of the llama3 template

Fixes # (issue)

## Before submitting

- [ x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ x] Did you write any new necessary tests?
