### PR TITLE
add ability to specify ray storage path

### DIFF
--- a/src/llamafactory/hparams/training_args.py
+++ b/src/llamafactory/hparams/training_args.py
@@ -16,7 +16,11 @@ class RayArguments:
 
     ray_run_name: Optional[str] = field(
         default=None,
-        metadata={"help": "The training results will be saved at `saves/ray_run_name`."},
+        metadata={"help": "The training results will be saved at `<ray_storage_path>/ray_run_name`."},
+    )
+    ray_storage_path: str = field(
+        default="./saves",
+        metadata={"help": "The storage path to save training results to"},
     )
     ray_num_workers: int = field(
         default=1,

--- a/src/llamafactory/train/trainer_utils.py
+++ b/src/llamafactory/train/trainer_utils.py
@@ -621,7 +621,7 @@ def get_ray_trainer(
         ),
         run_config=RunConfig(
             name=ray_args.ray_run_name,
-            storage_path=Path("./saves").absolute().as_posix(),
+            storage_path=Path(ray_args.ray_storage_path).absolute().as_posix(),
         ),
     )
     return trainer


### PR DESCRIPTION
# What does this PR do?

Adds ability to specify the `storage_path` argument in the ray `TorchTrainer` [RunConfig](https://docs.ray.io/en/latest/train/api/doc/ray.train.RunConfig.html#ray.train.RunConfig). This specifies the path to save checkpoints to, and is needed to save to shared cluster storage when dealing with multi-node training.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
