### PR TITLE
feat: webui add swanlab link

### DIFF
--- a/src/llamafactory/extras/constants.py
+++ b/src/llamafactory/extras/constants.py
@@ -87,6 +87,8 @@ STAGES_USE_PAIR_DATA = {"rm", "dpo"}
 
 SUPPORTED_CLASS_FOR_S2ATTN = {"llama"}
 
+SWANLAB_CONFIG = "swanlab_public_config.json"
+
 VIDEO_PLACEHOLDER = os.environ.get("VIDEO_PLACEHOLDER", "<video>")
 
 V_HEAD_WEIGHTS_NAME = "value_head.bin"

--- a/src/llamafactory/train/trainer_utils.py
+++ b/src/llamafactory/train/trainer_utils.py
@@ -17,6 +17,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+import os
 from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
@@ -31,7 +33,7 @@ from transformers.trainer_pt_utils import get_parameter_names
 from typing_extensions import override
 
 from ..extras import logging
-from ..extras.constants import IGNORE_INDEX
+from ..extras.constants import IGNORE_INDEX, SWANLAB_CONFIG
 from ..extras.packages import is_apollo_available, is_galore_available, is_ray_available
 from ..hparams import FinetuningArguments, ModelArguments
 from ..model import find_all_linear_modules, load_model, load_tokenizer, load_valuehead_params
@@ -51,7 +53,7 @@ if is_ray_available():
 
 
 if TYPE_CHECKING:
-    from transformers import PreTrainedModel, TrainerCallback
+    from transformers import PreTrainedModel, TrainerCallback, TrainerState
     from trl import AutoModelForCausalLMWithValueHead
 
     from ..hparams import DataArguments, RayArguments, TrainingArguments
@@ -587,41 +589,27 @@ def get_swanlab_callback(finetuning_args: "FinetuningArguments") -> "TrainerCall
     Gets the callback for logging to SwanLab.
     """
     import swanlab  # type: ignore
-    import os
-    import json
     from swanlab.integration.transformers import SwanLabCallback  # type: ignore
 
     if finetuning_args.swanlab_api_key is not None:
         swanlab.login(api_key=finetuning_args.swanlab_api_key)
-        
-    class LLaMAFactorySwanLabCallback(SwanLabCallback):
-        def setup(self, args, state, model, **kwargs):
-            self._initialized = True
+
+    class SwanLabCallbackExtension(SwanLabCallback):
+        def setup(self, args: "TrainingArguments", state: "TrainerState", model: "PreTrainedModel", **kwargs):
             if not state.is_world_process_zero:
                 return
-            swanlab.config["FRAMEWORK"] = "🤗transformers"
-            swanlab.config["UPPER_FRAMEWORK"] = "🦙LlamaFactory"
-            # If the experiment is not registered, register it
-            if self._experiment.get_run() is None:
-                self._experiment.init(**self._swanlab_init)
-            combined_dict = {}
-            if args:
-                combined_dict = {**args.to_sanitized_dict()}
-            # Set the config
-            if hasattr(model, "config") and model.config is not None:
-                model_config = model.config if isinstance(model.config, dict) else model.config.to_dict()
-                combined_dict = {**model_config, **combined_dict}
-            self._experiment.config.update(combined_dict)
-            # Write the config to the output directory
+
+            super().setup(args, state, model, **kwargs)
             swanlab_public_config = self._experiment.get_run().public.json()
-            with open(os.path.join(args.output_dir, "swanlab_public_config.json"), "w") as f:
-                f.write(json.dumps(swanlab_public_config, indent=4))
-        
-    swanlab_callback = LLaMAFactorySwanLabCallback(
+            with open(os.path.join(args.output_dir, SWANLAB_CONFIG), "w") as f:
+                f.write(json.dumps(swanlab_public_config, indent=2))
+
+    swanlab_callback = SwanLabCallbackExtension(
         project=finetuning_args.swanlab_project,
         workspace=finetuning_args.swanlab_workspace,
         experiment_name=finetuning_args.swanlab_run_name,
         mode=finetuning_args.swanlab_mode,
+        config={"Framework": "🦙LlamaFactory"},
     )
     return swanlab_callback
 

--- a/src/llamafactory/train/trainer_utils.py
+++ b/src/llamafactory/train/trainer_utils.py
@@ -594,7 +594,7 @@ def get_swanlab_callback(finetuning_args: "FinetuningArguments") -> "TrainerCall
     if finetuning_args.swanlab_api_key is not None:
         swanlab.login(api_key=finetuning_args.swanlab_api_key)
         
-    class LLaMAFactoryCallback(SwanLabCallback):
+    class LLaMAFactorySwanLabCallback(SwanLabCallback):
         def setup(self, args, state, model, **kwargs):
             self._initialized = True
             if not state.is_world_process_zero:
@@ -617,7 +617,7 @@ def get_swanlab_callback(finetuning_args: "FinetuningArguments") -> "TrainerCall
             with open(os.path.join(args.output_dir, "swanlab_public_config.json"), "w") as f:
                 f.write(json.dumps(swanlab_public_config, indent=4))
         
-    swanlab_callback = LLaMAFactoryCallback(
+    swanlab_callback = LLaMAFactorySwanLabCallback(
         project=finetuning_args.swanlab_project,
         workspace=finetuning_args.swanlab_workspace,
         experiment_name=finetuning_args.swanlab_run_name,

--- a/src/llamafactory/webui/components/train.py
+++ b/src/llamafactory/webui/components/train.py
@@ -299,10 +299,18 @@ def create_train_tab(engine: "Engine") -> Dict[str, "Component"]:
             swanlab_workspace = gr.Textbox()
             swanlab_api_key = gr.Textbox()
             swanlab_mode = gr.Dropdown(choices=["cloud", "local"], value="cloud")
-            swanlab_link = gr.Textbox()
+            swanlab_link = gr.Markdown(visible=False, container=True)
 
     input_elems.update(
-        {use_swanlab, swanlab_project, swanlab_run_name, swanlab_workspace, swanlab_api_key, swanlab_mode, swanlab_link}
+        {
+            use_swanlab,
+            swanlab_project,
+            swanlab_run_name,
+            swanlab_workspace,
+            swanlab_api_key,
+            swanlab_mode,
+            swanlab_link,
+        }
     )
     elem_dict.update(
         dict(

--- a/src/llamafactory/webui/components/train.py
+++ b/src/llamafactory/webui/components/train.py
@@ -299,9 +299,10 @@ def create_train_tab(engine: "Engine") -> Dict[str, "Component"]:
             swanlab_workspace = gr.Textbox()
             swanlab_api_key = gr.Textbox()
             swanlab_mode = gr.Dropdown(choices=["cloud", "local"], value="cloud")
+            swanlab_link = gr.Textbox()
 
     input_elems.update(
-        {use_swanlab, swanlab_project, swanlab_run_name, swanlab_workspace, swanlab_api_key, swanlab_mode}
+        {use_swanlab, swanlab_project, swanlab_run_name, swanlab_workspace, swanlab_api_key, swanlab_mode, swanlab_link}
     )
     elem_dict.update(
         dict(
@@ -312,6 +313,7 @@ def create_train_tab(engine: "Engine") -> Dict[str, "Component"]:
             swanlab_workspace=swanlab_workspace,
             swanlab_api_key=swanlab_api_key,
             swanlab_mode=swanlab_mode,
+            swanlab_link=swanlab_link,
         )
     )
 
@@ -364,7 +366,7 @@ def create_train_tab(engine: "Engine") -> Dict[str, "Component"]:
             loss_viewer=loss_viewer,
         )
     )
-    output_elems = [output_box, progress_bar, loss_viewer]
+    output_elems = [output_box, progress_bar, loss_viewer, swanlab_link]
 
     cmd_preview_btn.click(engine.runner.preview_train, input_elems, output_elems, concurrency_limit=None)
     start_btn.click(engine.runner.run_train, input_elems, output_elems)

--- a/src/llamafactory/webui/control.py
+++ b/src/llamafactory/webui/control.py
@@ -14,7 +14,6 @@
 
 import json
 import os
-import yaml
 from typing import Any, Dict, List, Optional, Tuple
 
 from transformers.trainer_utils import get_last_checkpoint
@@ -24,6 +23,7 @@ from ..extras.constants import (
     PEFT_METHODS,
     RUNNING_LOG,
     STAGES_USE_PAIR_DATA,
+    SWANLAB_CONFIG,
     TRAINER_LOG,
     TRAINING_STAGES,
 )
@@ -31,6 +31,7 @@ from ..extras.packages import is_gradio_available, is_matplotlib_available
 from ..extras.ploting import gen_loss_plot
 from ..model import QuantizationMethod
 from .common import DEFAULT_CONFIG_DIR, DEFAULT_DATA_DIR, get_model_path, get_save_dir, get_template, load_dataset_info
+from .locales import ALERTS
 
 
 if is_gradio_available():
@@ -87,22 +88,21 @@ def get_model_info(model_name: str) -> Tuple[str, str]:
     return get_model_path(model_name), get_template(model_name)
 
 
-def get_trainer_info(output_path: os.PathLike, do_train: bool) -> Tuple[str, "gr.Slider", Optional["gr.Plot"]]:
+def get_trainer_info(lang: str, output_path: os.PathLike, do_train: bool) -> Tuple[str, "gr.Slider", Dict[str, Any]]:
     r"""
     Gets training infomation for monitor.
 
     If do_train is True:
-        Inputs: train.output_path
-        Outputs: train.output_box, train.progress_bar, train.loss_viewer
+        Inputs: top.lang, train.output_path
+        Outputs: train.output_box, train.progress_bar, train.loss_viewer, train.swanlab_link
     If do_train is False:
-        Inputs: eval.output_path
-        Outputs: eval.output_box, eval.progress_bar, None
+        Inputs: top.lang, eval.output_path
+        Outputs: eval.output_box, eval.progress_bar, None, None
     """
     running_log = ""
     running_progress = gr.Slider(visible=False)
-    running_loss = None
-    swanlab_exp_link = "waiting"
-    
+    running_info = {}
+
     running_log_path = os.path.join(output_path, RUNNING_LOG)
     if os.path.isfile(running_log_path):
         with open(running_log_path, encoding="utf-8") as f:
@@ -127,23 +127,19 @@ def get_trainer_info(output_path: os.PathLike, do_train: bool) -> Tuple[str, "gr
             running_progress = gr.Slider(label=label, value=percentage, visible=True)
 
             if do_train and is_matplotlib_available():
-                running_loss = gr.Plot(gen_loss_plot(trainer_log))
+                running_info["loss_viewer"] = gr.Plot(gen_loss_plot(trainer_log))
 
-    swanlab_config_path = os.path.join(output_path, "swanlab_public_config.json")
+    swanlab_config_path = os.path.join(output_path, SWANLAB_CONFIG)
     if os.path.isfile(swanlab_config_path):
         with open(swanlab_config_path, encoding="utf-8") as f:
             swanlab_public_config = json.load(f)
-            swanlab_exp_link = swanlab_public_config["cloud"]["experiment_url"]
-            if swanlab_exp_link is None:  # local mode
-                swanlab_exp_link = "only show link in cloud mode"
-    training_args_path = os.path.join(output_path, "llamaboard_config.yaml")
-    if os.path.isfile(training_args_path):
-        with open(training_args_path, encoding="utf-8") as f:
-            use_swanlab = yaml.load(f, Loader=yaml.FullLoader)["train.use_swanlab"]
-            if not use_swanlab:
-                swanlab_exp_link = "not using swanlab"  # not using swanlab
+            swanlab_link = swanlab_public_config["cloud"]["experiment_url"]
+            if swanlab_link is not None:
+                running_info["swanlab_link"] = gr.Markdown(
+                    ALERTS["info_swanlab_link"][lang] + swanlab_link, visible=True
+                )
 
-    return running_log, running_progress, running_loss, swanlab_exp_link
+    return running_log, running_progress, running_info
 
 
 def list_checkpoints(model_name: str, finetuning_type: str) -> "gr.Dropdown":

--- a/src/llamafactory/webui/locales.py
+++ b/src/llamafactory/webui/locales.py
@@ -1894,28 +1894,6 @@ LOCALES = {
             "info": "クラウド版またはオフライン版 SwanLab を使用します。",
         },
     },
-    "swanlab_link": {
-        "en": {
-            "label": "SwanLab link",
-            "info": "Experimental links in Cloud mode"
-        },
-        "ru": {
-            "label": "SwanLab ссылка",
-            "info": "Ссылка на SwanLab (cloud mode)"
-        },
-        "zh": {
-            "label": "SwanLab 链接",
-            "info": "Cloud模式下的实验链接",
-        },
-        "ko": {
-            "label": "SwanLab 링크",
-            "info": "SwanLab 의 링크 (cloud mode)"
-        },
-        "ja": {
-            "label": "SwanLab リンク",
-            "info": "SwanLab のリンク (cloud mode)"
-        },
-    },
     "cmd_preview_btn": {
         "en": {
             "value": "Preview command",
@@ -2835,5 +2813,12 @@ ALERTS = {
         "zh": "模型导出完成。",
         "ko": "모델이 내보내졌습니다.",
         "ja": "モデルのエクスポートが完了しました。",
+    },
+    "info_swanlab_link": {
+        "en": "### SwanLab Link\n",
+        "ru": "### SwanLab ссылка\n",
+        "zh": "### SwanLab 链接\n",
+        "ko": "### SwanLab 링크\n",
+        "ja": "### SwanLab リンク\n",
     },
 }

--- a/src/llamafactory/webui/locales.py
+++ b/src/llamafactory/webui/locales.py
@@ -1894,6 +1894,28 @@ LOCALES = {
             "info": "クラウド版またはオフライン版 SwanLab を使用します。",
         },
     },
+    "swanlab_link": {
+        "en": {
+            "label": "SwanLab link",
+            "info": "Experimental links in Cloud mode"
+        },
+        "ru": {
+            "label": "SwanLab ссылка",
+            "info": "Ссылка на SwanLab (cloud mode)"
+        },
+        "zh": {
+            "label": "SwanLab 链接",
+            "info": "Cloud模式下的实验链接",
+        },
+        "ko": {
+            "label": "SwanLab 링크",
+            "info": "SwanLab 의 링크 (cloud mode)"
+        },
+        "ja": {
+            "label": "SwanLab リンク",
+            "info": "SwanLab のリンク (cloud mode)"
+        },
+    },
     "cmd_preview_btn": {
         "en": {
             "value": "Preview command",

--- a/src/llamafactory/webui/runner.py
+++ b/src/llamafactory/webui/runner.py
@@ -423,7 +423,8 @@ class Runner:
         output_box = self.manager.get_elem_by_id("{}.output_box".format("train" if self.do_train else "eval"))
         progress_bar = self.manager.get_elem_by_id("{}.progress_bar".format("train" if self.do_train else "eval"))
         loss_viewer = self.manager.get_elem_by_id("train.loss_viewer") if self.do_train else None
-
+        swanlab_link = self.manager.get_elem_by_id("train.swanlab_link") if self.do_train else None
+        
         running_log = ""
         while self.trainer is not None:
             if self.aborted:
@@ -432,16 +433,16 @@ class Runner:
                     progress_bar: gr.Slider(visible=False),
                 }
             else:
-                running_log, running_progress, running_loss = get_trainer_info(output_path, self.do_train)
+                running_log, running_progress, running_loss, swanlab_exp_link = get_trainer_info(output_path, self.do_train)
                 return_dict = {
                     output_box: running_log,
                     progress_bar: running_progress,
                 }
+                if swanlab_exp_link is not None:
+                    return_dict[swanlab_link] = swanlab_exp_link
                 if running_loss is not None:
                     return_dict[loss_viewer] = running_loss
-
                 yield return_dict
-
             try:
                 self.trainer.wait(2)
                 self.trainer = None

--- a/src/llamafactory/webui/runner.py
+++ b/src/llamafactory/webui/runner.py
@@ -424,7 +424,7 @@ class Runner:
         progress_bar = self.manager.get_elem_by_id("{}.progress_bar".format("train" if self.do_train else "eval"))
         loss_viewer = self.manager.get_elem_by_id("train.loss_viewer") if self.do_train else None
         swanlab_link = self.manager.get_elem_by_id("train.swanlab_link") if self.do_train else None
-        
+
         running_log = ""
         while self.trainer is not None:
             if self.aborted:
@@ -433,15 +433,17 @@ class Runner:
                     progress_bar: gr.Slider(visible=False),
                 }
             else:
-                running_log, running_progress, running_loss, swanlab_exp_link = get_trainer_info(output_path, self.do_train)
+                running_log, running_progress, running_info = get_trainer_info(lang, output_path, self.do_train)
                 return_dict = {
                     output_box: running_log,
                     progress_bar: running_progress,
                 }
-                if swanlab_exp_link is not None:
-                    return_dict[swanlab_link] = swanlab_exp_link
-                if running_loss is not None:
-                    return_dict[loss_viewer] = running_loss
+                if "loss_viewer" in running_info:
+                    return_dict[loss_viewer] = running_info["loss_viewer"]
+
+                if "swanlab_link" in running_info:
+                    return_dict[swanlab_link] = running_info["swanlab_link"]
+
                 yield return_dict
             try:
                 self.trainer.wait(2)


### PR DESCRIPTION
This PR adds a "SwanLab Link" Textbox to the SwanLab module in the WebUI.  
The Textbox retrieves and displays the SwanLab experiment link in the WebUI after training starts:

<img width="1538" alt="image" src="https://github.com/user-attachments/assets/0085cd1b-7bbb-4b6d-bb7c-d442396d0a8c" />

Additional details:
1. A new `LLaMAFactorySwanLabCallback` class is introduced to save `swanlab_public_config.json` to the output directory when creating a SwanLab experiment.
2. When `use_swanlab` is disabled, the "SwanLab Link" displays "not using swanlab".
3. When `use_swanlab` is enabled and `local` mode is selected, the "SwanLab Link" displays "only show link in cloud mode".
4. While waiting for the experiment link to be generated, the "SwanLab Link" displays "waiting".