### PR TITLE
Fix the issue of missing think tag in FunctionFormatter.apply

### DIFF
--- a/src/llamafactory/data/formatter.py
+++ b/src/llamafactory/data/formatter.py
@@ -121,7 +121,7 @@ class FunctionFormatter(StringFormatter):
 
         function_str = self.tool_utils.function_formatter(functions)
         if thought:
-            function_str = thought.group(1) + function_str
+            function_str = thought.group(0) + function_str
 
         return super().apply(content=function_str)
 


### PR DESCRIPTION
# What does this PR do?
This PR fix a issue of think tag splicing in FunctionFormatter.apply

Fixes #7064

## Before submitting
![image](https://github.com/user-attachments/assets/6959c35f-40bf-4438-bff0-a683d2f0b968)
## After  submitting
![image](https://github.com/user-attachments/assets/37d4eaad-6c94-46c6-8f17-324fcc8d352f)

