### PR TITLE
Fix `ultrachat_200k` dataset

### DIFF
--- a/data/dataset_info.json
+++ b/data/dataset_info.json
@@ -232,6 +232,7 @@
   "ultrachat_200k": {
     "hf_hub_url": "HuggingFaceH4/ultrachat_200k",
     "ms_hub_url": "AI-ModelScope/ultrachat_200k",
+    "split": "train_sft",
     "formatting": "sharegpt",
     "columns": {
       "messages": "messages"


### PR DESCRIPTION
# What does this PR do?

Fixes the 'split' for the `HuggingFaceH4/ultrachat_200k` dataset, as it doesn't contain the default "train" split.

<img width="495" alt="image" src="https://github.com/user-attachments/assets/53df9fb0-9dea-44ec-8450-f698abc0682a" />

## Before submitting

- [X] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [X] Did you write any new necessary tests?
