### PR TITLE
use position_ids for neat_packing with fa2

### DIFF
--- a/src/llamafactory/data/collator.py
+++ b/src/llamafactory/data/collator.py
@@ -221,11 +221,8 @@ class SFTDataCollatorWith4DAttentionMask(MultiModalDataCollatorForSeq2Seq):
 
     def __call__(self, features: list[dict[str, Any]]) -> dict[str, "torch.Tensor"]:
         features = super().__call__(features)
-        if self.block_diag_attn:
-            if self.attn_implementation != "flash_attention_2":
-                features["attention_mask"] = prepare_4d_attention_mask(features["attention_mask"], self.compute_dtype)
-            else:
-                features["attention_mask"] = features["attention_mask"] > 0
+        if self.block_diag_attn and self.attn_implementation != "flash_attention_2":
+            features["attention_mask"] = prepare_4d_attention_mask(features["attention_mask"], self.compute_dtype)
 
         for key, value in features.items():  # cast data dtype for paligemma
             if torch.is_tensor(value) and torch.is_floating_point(value):

--- a/src/llamafactory/data/collator.py
+++ b/src/llamafactory/data/collator.py
@@ -221,8 +221,11 @@ class SFTDataCollatorWith4DAttentionMask(MultiModalDataCollatorForSeq2Seq):
 
     def __call__(self, features: list[dict[str, Any]]) -> dict[str, "torch.Tensor"]:
         features = super().__call__(features)
-        if self.block_diag_attn and self.attn_implementation != "flash_attention_2":
-            features["attention_mask"] = prepare_4d_attention_mask(features["attention_mask"], self.compute_dtype)
+        if self.block_diag_attn:
+            if self.attn_implementation != "flash_attention_2":
+                features["attention_mask"] = prepare_4d_attention_mask(features["attention_mask"], self.compute_dtype)
+            else:
+                features["attention_mask"] = features["attention_mask"] > 0
 
         for key, value in features.items():  # cast data dtype for paligemma
             if torch.is_tensor(value) and torch.is_floating_point(value):


### PR DESCRIPTION
# What does this PR do?
When using `neat_packing` with SFT and `fa2`, the generated `attention_mask` looks like `[1,1,1,1,..2,2,2,...3,3,3...0,0,0,0]` (`attention_mask_with_indices`).
However transformers expect `attention_mask` to be a bool like tensor (bool or an int tensor with 1s and 0s).

We add `position_ids` in `PackedSupervisedDatasetProcessor` incase of `neat_packing` and flip `attention_mask` to be boolean.

 ## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?
