### PR TITLE
[data] specify position_ids in PackedSupervisedDatasetProcessor for neat_packing

### DIFF
--- a/src/llamafactory/data/collator.py
+++ b/src/llamafactory/data/collator.py
@@ -221,11 +221,8 @@ class SFTDataCollatorWith4DAttentionMask(MultiModalDataCollatorForSeq2Seq):
 
     def __call__(self, features: list[dict[str, Any]]) -> dict[str, "torch.Tensor"]:
         features = super().__call__(features)
-        if self.block_diag_attn:
-            if self.attn_implementation != "flash_attention_2":
-                features["attention_mask"] = prepare_4d_attention_mask(features["attention_mask"], self.compute_dtype)
-            else:
-                features["attention_mask"] = features["attention_mask"] > 0
+        if self.block_diag_attn and self.attn_implementation != "flash_attention_2":
+            features["attention_mask"] = prepare_4d_attention_mask(features["attention_mask"], self.compute_dtype)
 
         for key, value in features.items():  # cast data dtype for paligemma
             if torch.is_tensor(value) and torch.is_floating_point(value):

--- a/src/llamafactory/data/collator.py
+++ b/src/llamafactory/data/collator.py
@@ -221,8 +221,11 @@ class SFTDataCollatorWith4DAttentionMask(MultiModalDataCollatorForSeq2Seq):
 
     def __call__(self, features: list[dict[str, Any]]) -> dict[str, "torch.Tensor"]:
         features = super().__call__(features)
-        if self.block_diag_attn and self.attn_implementation != "flash_attention_2":
-            features["attention_mask"] = prepare_4d_attention_mask(features["attention_mask"], self.compute_dtype)
+        if self.block_diag_attn:
+            if self.attn_implementation != "flash_attention_2":
+                features["attention_mask"] = prepare_4d_attention_mask(features["attention_mask"], self.compute_dtype)
+            else:
+                features["attention_mask"] = features["attention_mask"] > 0
 
         for key, value in features.items():  # cast data dtype for paligemma
             if torch.is_tensor(value) and torch.is_floating_point(value):


### PR DESCRIPTION
# What does this PR do?
In current `neat_packing` we don't use `position_ids` along with the 4D attention mask, 

Even though the 4D mask prevents cross sequence attention, `neat_packing` is still different from no packing, since the model perceives (position encoding difference) later sentence position different in comparison to no packing. 

In this PR, we add `position_ids` for sentences when `neat_packing` is specified, which allows the tokens position to be perceived (proper position encoding) properly as if there's no packing.

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?