### PR TITLE
Running SGLang

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ extra_require = {
     "awq": ["autoawq"],
     "aqlm": ["aqlm[gpu]>=1.1.0"],
     "vllm": ["vllm>=0.4.3,<=0.7.3"],
-    "sglang": ["sglang>=0.4.4"],
+    "sglang": ["sglang>=0.4.4", "transformers==4.48.3"],
     "galore": ["galore-torch"],
     "apollo": ["apollo-torch"],
     "badam": ["badam>=1.2.1"],

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ extra_require = {
     "awq": ["autoawq"],
     "aqlm": ["aqlm[gpu]>=1.1.0"],
     "vllm": ["vllm>=0.4.3,<=0.7.3"],
-    "sglang": ["sglang>=0.4.4", "transformers==4.48.3"],
+    "sglang": ["sglang[srt]>=0.4.4", "transformers==4.48.3"],
     "galore": ["galore-torch"],
     "apollo": ["apollo-torch"],
     "badam": ["badam>=1.2.1"],


### PR DESCRIPTION
# What does this PR do?

Fixes Running SGLang.
- SGLang requires SGLang Runtime (`srt`)
- https://github.com/sgl-project/sglang/issues/4629 : transformers version conflict reported in sglang community
```
ValueError: '<class 'sglang.srt.configs.qwen2_5_vl_config.Qwen2_5_VLConfig'>' is already used by a Transformers model
```
And the suggested workaround is to use `transformers==4.48.3`.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?
