### PR TITLE
nvidia cuda image update with transformer upgrade to 4.50.0

### DIFF
--- a/docker/docker-cuda/Dockerfile
+++ b/docker/docker-cuda/Dockerfile
@@ -1,6 +1,6 @@
-# Default use the NVIDIA official image with PyTorch 2.3.0
+# Default use the NVIDIA official image with PyTorch 2.6.0
 # https://docs.nvidia.com/deeplearning/frameworks/pytorch-release-notes/index.html
-ARG BASE_IMAGE=nvcr.io/nvidia/pytorch:24.02-py3
+ARG BASE_IMAGE=nvcr.io/nvidia/pytorch:24.12-py3
 FROM ${BASE_IMAGE}
 
 # Define environments


### PR DESCRIPTION
# What does this PR do?

Because flatten_with_keys_fn causes an error depending on the torch version, the NVIDIA official image used was updated to PyTorch 2.6.0, pytorch:24.12-py3.
https://github.com/huggingface/transformers/issues/36888

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?
