### PR TITLE
Enable Liger-Kernel for Gemma3

### DIFF
--- a/src/llamafactory/model/model_utils/liger_kernel.py
+++ b/src/llamafactory/model/model_utils/liger_kernel.py
@@ -74,6 +74,8 @@ def apply_liger_kernel(
         from liger_kernel.transformers import apply_liger_kernel_to_gemma as apply_liger_kernel
     elif model_type == "gemma2":
         from liger_kernel.transformers import apply_liger_kernel_to_gemma2 as apply_liger_kernel
+    elif model_type == "gemma3":
+        from liger_kernel.transformers import apply_liger_kernel_to_gemma3 as apply_liger_kernel
     elif model_type == "llama":
         from liger_kernel.transformers import apply_liger_kernel_to_llama as apply_liger_kernel
     elif model_type == "mistral":


### PR DESCRIPTION
# What does this PR do?

This is a preperation for the [PR](https://github.com/linkedin/Liger-Kernel/pull/621) of Gemma3 support in Liger-Kernel repositoy, which passed the tests and waiting to be merged and release as a new version.

I had tested it on my machine with RTX3090 by finetuing a Gemma3 model with Llama-factory, I can see the log message that Liger-Kernel has been applied to the model, and also the reductions to occupied VRAM and increased throughput, as expected.

As the PR in Liger-Kernel has been reviewed, the monkey patch with `apply_liger_kernel_to_gemma3` is unlikely to change.

We can wait for the Liger Kernel release and then merge this PR.
 
## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?
