### PR TITLE
New mismatch pair creation strategy

### DIFF
--- a/src/llamafactory/data/processor/feedback.py
+++ b/src/llamafactory/data/processor/feedback.py
@@ -83,8 +83,8 @@ class FeedbackDatasetProcessor(DatasetProcessor):
         return input_ids, labels, kl_input_ids, kl_labels, kto_tag
 
     def preprocess_dataset(self, examples: dict[str, list[Any]]) -> dict[str, list[Any]]:
-        # create unrelated input-output pairs for estimating the KL term by flipping the matched pairs
-        kl_response = examples["_response"][::-1]
+        # Creates mismatched pairs of prompts and completions for the KL dataset by adding a +1 offset to the order of completions.
+        kl_response = [examples["_response"][-1]] + examples["_response"][:-1]
         model_inputs = defaultdict(list)
         for i in range(len(examples["_prompt"])):
             if len(examples["_prompt"][i]) % 2 != 1 or len(examples["_response"][i]) < 2:


### PR DESCRIPTION
# What does this PR do?

During KTO training, `FeedbackDatasetProcessor` calculates the KL term by reversing the labels. This usually works, except on odd batch sizes, in which case the middle will be a match.

And this has been updated in [huggingface/trl](https://github.com/huggingface/trl) by [this PR](https://github.com/huggingface/trl/pull/1970) according to [this issue](https://github.com/huggingface/trl/issues/1911).

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
YES

- [ ] Did you write any new necessary tests?
NO, there is no new necessary test.