### PR TITLE
Shard the dataset to allow multiprocessing when streaming is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Compared to ChatGLM's [P-Tuning](https://github.com/THUDM/ChatGLM2-6B/tree/main/
 
 [23/08/11] We supported **[DPO training](https://arxiv.org/abs/2305.18290)** for instruction-tuned models. See [examples](examples/README.md) for usage.
 
-[23/07/31] We supported **dataset streaming**. Try `streaming: true` and `max_steps: 10000` arguments to load your dataset in streaming mode.
+[23/07/31] We supported **dataset streaming**. Try `streaming: true` and `max_steps: 10000` arguments to load your dataset in streaming mode. Use `dataset_shards` to enable parallel preprocessing with streaming.
 
 [23/07/29] We released two instruction-tuned 13B models at Hugging Face. See these Hugging Face Repos ([LLaMA-2](https://huggingface.co/hiyouga/Llama-2-Chinese-13b-chat) / [Baichuan](https://huggingface.co/hiyouga/Baichuan-13B-sft)) for details.
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -206,7 +206,7 @@ https://github.com/user-attachments/assets/43b700c6-a178-41db-b1f8-8190a5d3fcfc
 
 [23/08/11] 我们支持了指令模型的 **[DPO 训练](https://arxiv.org/abs/2305.18290)**。详细用法请参照 [examples](examples/README_zh.md)。
 
-[23/07/31] 我们支持了**数据流式加载**。请使用 `streaming: true` 和 `max_steps: 10000` 参数来流式加载数据集。
+[23/07/31] 我们支持了**数据流式加载**。请使用 `streaming: true` 和 `max_steps: 10000` 参数来流式加载数据集。 用 `dataset_shards` 来开启多进程加载。
 
 [23/07/29] 我们在 Hugging Face 发布了两个 13B 指令微调模型。详细内容请查阅我们的 Hugging Face 项目（[LLaMA-2](https://huggingface.co/hiyouga/Llama-2-Chinese-13b-chat) / [Baichuan](https://huggingface.co/hiyouga/Baichuan-13B-sft)）。
 

--- a/src/llamafactory/data/loader.py
+++ b/src/llamafactory/data/loader.py
@@ -101,10 +101,11 @@ def _load_single_dataset(
             split=dataset_attr.split,
             cache_dir=cache_dir,
             token=model_args.ms_hub_token,
-            use_streaming=data_args.streaming,
         )
         if isinstance(dataset, MsDataset):
             dataset = dataset.to_hf_dataset()
+        if data_args.streaming:
+            dataset = dataset.to_iterable_dataset(num_shards=data_args.dataset_shards)
 
     elif dataset_attr.load_from == "om_hub":
         check_version("openmind>=0.8.0", mandatory=True)
@@ -131,10 +132,11 @@ def _load_single_dataset(
             split=dataset_attr.split,
             cache_dir=model_args.cache_dir,
             token=model_args.hf_hub_token,
-            streaming=data_args.streaming,
             num_proc=data_args.preprocessing_num_workers,
             trust_remote_code=model_args.trust_remote_code,
         )
+        if data_args.streaming:
+            dataset = dataset.to_iterable_dataset(num_shards=data_args.dataset_shards)
 
     if dataset_attr.num_samples is not None and not data_args.streaming:
         target_num = dataset_attr.num_samples

--- a/src/llamafactory/data/loader.py
+++ b/src/llamafactory/data/loader.py
@@ -101,10 +101,11 @@ def _load_single_dataset(
             split=dataset_attr.split,
             cache_dir=cache_dir,
             token=model_args.ms_hub_token,
+            use_streaming=data_args.streaming and not data_args.dataset_shards,  # only set to True when user specified streaming but do not want dataset to be sharded
         )
         if isinstance(dataset, MsDataset):
             dataset = dataset.to_hf_dataset()
-        if data_args.streaming:
+        if data_args.streaming and data_args.dataset_shards:
             dataset = dataset.to_iterable_dataset(num_shards=data_args.dataset_shards)
 
     elif dataset_attr.load_from == "om_hub":
@@ -134,8 +135,9 @@ def _load_single_dataset(
             token=model_args.hf_hub_token,
             num_proc=data_args.preprocessing_num_workers,
             trust_remote_code=model_args.trust_remote_code,
+            streaming=data_args.streaming and not data_args.dataset_shards,
         )
-        if data_args.streaming:
+        if data_args.streaming and data_args.dataset_shards:
             dataset = dataset.to_iterable_dataset(num_shards=data_args.dataset_shards)
 
     if dataset_attr.num_samples is not None and not data_args.streaming:

--- a/src/llamafactory/hparams/data_args.py
+++ b/src/llamafactory/hparams/data_args.py
@@ -83,6 +83,10 @@ class DataArguments:
         default=None,
         metadata={"help": "The number of processes to use for the pre-processing."},
     )
+    dataset_shards: Optional[int] = field(
+        default=None,
+        metadata={"help": "The number of shards to split the dataset into. Only used in streaming mode. This number limits the number of dataloader workers that can be used on a streaming dataset, thus should be set to the same as dataloader_num_workers."},
+    )
     max_samples: Optional[int] = field(
         default=None,
         metadata={"help": "For debugging purposes, truncate the number of examples for each dataset."},

--- a/src/llamafactory/hparams/data_args.py
+++ b/src/llamafactory/hparams/data_args.py
@@ -85,7 +85,7 @@ class DataArguments:
     )
     dataset_shards: Optional[int] = field(
         default=None,
-        metadata={"help": "The number of shards to split the dataset into. Only used in streaming mode. This number limits the number of dataloader workers that can be used on a streaming dataset, thus should be set to the same as dataloader_num_workers."},
+        metadata={"help": "The number of shards to split the dataset into. Only used in streaming mode. This should be set to the same as dataloader_num_workers. Not setting this while streaming data will cause the dataset to be non-sharded and thus only can be processed using one worker."},
     )
     max_samples: Optional[int] = field(
         default=None,


### PR DESCRIPTION
# What does this PR do?

This addresses a limitation introduced by https://github.com/hiyouga/LLaMA-Factory/pull/5346

Currently, if you use streaming, you cannot do multiprocessing by setting `dataloader_num_workers` as they will always be restricted to one worker due to the dataset not being sharded. As a result, user will see `Too many dataloader workers: XXX (max is dataset.num_shards=1). Stopping XXX dataloader workers`.

This causes anyone who tries to stream data to suffer a huge speed bottleneck as preprocessing is basically limited to one CPU core per process, especially on preprocessing-heavy datasets like videos. There is also no indication when this is happening, so to the users, it seems like their code is stuck.

In order to allow for multiple dataloader workers to work on a streaming dataset, it must first be loaded as a normal `Dataset`, then converted to an `ItertableDataset` and shard it.

Ideally the `num_shards` should be equal to the `dataloader_num_workers` in the yaml config, but I could not find how to get this value as there are no usages of it within this codebase. Perhaps @hiyouga could enlighten me on this. For now, I have made a new argument named `dataset_shards`. 

Note that when doing multi-gpu training, this `dataset_shards` and `dataloader_num_workers` will be multiplied per GPU used, so on a 64-core system with 8 gpus, one should not set a value higher than 64/8=8, else the system might be overloaded. 

This has been tested on full sft on both single and multi GPU, with streaming dataset from local disk.

There is a limitation, which is when you load the dataset first with streaming=False, it will download all files required. If the user wants to stream it from the Internet (instead of from local storage), then this would lead to a long download time. For those with data already locally cached, this is not a concern.

To address the above limitation, and also to maintain backward compatibility, the new `dataset_shards` parameter will default to `None`, and only when it is explicitly defined, then this new behavior of sharding will kick in. Otherwise, it will remain the current behavior: stream with a single dataloader worker.

Therefore, the expected use case for this would be:
1. User have a large dataset stored on a locally accessible file system (local disk, NFS etc.), and loading them in full will not fit into RAM or takes too long to tokenize and preprocess.
2. User want to start training on GPU asap without waiting for preprocessing of the full dataset to be done.

The PR does not support `openmind` datasets yet as I could not find a equivalent sharding function of this library.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?
