### PR TITLE
fix qwen-omni video ft

### DIFF
--- a/src/llamafactory/data/collator.py
+++ b/src/llamafactory/data/collator.py
@@ -203,7 +203,6 @@ class MultiModalDataCollatorForSeq2Seq(DataCollatorForSeq2Seq):
 
                 delta0 = (1 - rope_index_kwargs["attention_mask"]).sum(dim=-1).unsqueeze(1)
                 # avoid conflict
-                rope_index_kwargs["second_per_grids"] = mm_inputs.get("video_second_per_grid", None)
                 new_position_ids, rope_deltas = self.model.get_rope_index(**rope_index_kwargs)
                 features["position_ids"], features["rope_deltas"] = (
                     new_position_ids.clone(),

--- a/src/llamafactory/data/mm_plugin.py
+++ b/src/llamafactory/data/mm_plugin.py
@@ -1405,7 +1405,7 @@ class Qwen2OmniPlugin(Qwen2VLPlugin):
                             video_grid_thw[num_video_tokens][2] // self.image_processor.merge_size,
                         )
                         .flatten()
-                        * mm_inputs["video_second_per_grid"][num_video_tokens]
+                        * mm_inputs["second_per_grid_ts"][num_video_tokens]
                         * 25  # FIXME hardcode of position_id_per_seconds=25
                     ).long()
                     t_ntoken_per_chunk = 50  # FIXME hardcode: [25 * 2]


### PR DESCRIPTION
# What does this PR do?
Fix the error when using the `video-text-to-text` dataset.
`video_second_per_grid` should not be `None`, or it will raise an error:
```
[rank0]:   File ".../transformers/models/qwen2_5_omni/modeling_qwen2_5_omni.py", line 397, in get_rope_index
[rank0]:     torch.arange(grid_t) * second_per_grids[video_idx].cpu().float() * position_id_per_seconds
[rank0]: TypeError: 'NoneType' object is not subscriptable
```
https://github.com/hiyouga/LLaMA-Factory/blob/903db09822b167dbe2d361aadb521e3c6caaad7a/src/llamafactory/data/collator.py#L196-L206
Fixes # (issue)

## Before submitting

- [ ] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?
