### PR TITLE
[data] Qwen2_5Omni nit

### DIFF
--- a/src/llamafactory/data/collator.py
+++ b/src/llamafactory/data/collator.py
@@ -203,7 +203,6 @@ class MultiModalDataCollatorForSeq2Seq(DataCollatorForSeq2Seq):
 
                 delta0 = (1 - rope_index_kwargs["attention_mask"]).sum(dim=-1).unsqueeze(1)
                 # avoid conflict
-                rope_index_kwargs["second_per_grids"] = mm_inputs.get("video_second_per_grid", None)
                 new_position_ids, rope_deltas = self.model.get_rope_index(**rope_index_kwargs)
                 features["position_ids"], features["rope_deltas"] = (
                     new_position_ids.clone(),

--- a/src/llamafactory/data/mm_plugin.py
+++ b/src/llamafactory/data/mm_plugin.py
@@ -1405,7 +1405,7 @@ class Qwen2OmniPlugin(Qwen2VLPlugin):
                             video_grid_thw[num_video_tokens][2] // self.image_processor.merge_size,
                         )
                         .flatten()
-                        * mm_inputs["video_second_per_grid"][num_video_tokens]
+                        * mm_inputs["second_per_grid_ts"][num_video_tokens]
                         * 25  # FIXME hardcode of position_id_per_seconds=25
                     ).long()
                     t_ntoken_per_chunk = 50  # FIXME hardcode: [25 * 2]

--- a/src/llamafactory/model/loader.py
+++ b/src/llamafactory/model/loader.py
@@ -157,7 +157,7 @@ def load_model(
                 model = load_class.from_config(config, trust_remote_code=model_args.trust_remote_code)
             else:
                 model = load_class.from_pretrained(**init_kwargs)
-                if load_class is AutoModelForTextToWaveform:
+                if getattr(model.config, "model_type", None) == "qwen2_5_omni":
                     model = model.thinker  # use part of Omni model
 
         if model_args.mixture_of_depths == "convert":


### PR DESCRIPTION
# What does this PR do?
 1. align the `video_second_per_grid` and `second_per_grids` with `second_per_grid_ts`, they should be the same thing.
 2. specify the `qwen2_omni` entry for now in `loader.py`.
 3. update the scripts for merging [`thinker`, `thinker_lora`,  base_model  | `thinker_ft`, base_model ].
 ## For usage
```bash
# for lora
python3 ./scripts/qwen_omni_full.py merge_lora \
  --base_model_path="./Qwen2_5Omni" \
  --lora_checkpoint_path="./lora_checkpoint" \
  --save_path="./target_dir"

# for full ft
python3 ./scripts/qwen_omni_full.py save_full \
  --base_model_path="./Qwen2_5Omni" \
  --saved_thinker_path="./saved_thinker" \
  --save_path="./target_dir"
```
 
## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?
