### PR TITLE
[trainer] Refactor mini-batch input handling in PPO trainer

### DIFF
--- a/src/llamafactory/train/ppo/trainer.py
+++ b/src/llamafactory/train/ppo/trainer.py
@@ -241,9 +241,11 @@ class CustomPPOTrainer(PPOTrainer, Trainer):
             self.tokenizer.padding_side = "right"  # change padding side
             queries, responses, rewards = [], [], []
             for idx in range(0, self.config.batch_size, self.config.mini_batch_size):
-                mini_batch_queries, mini_batch_responses = self.get_inputs(
-                    batch[idx : idx + self.config.mini_batch_size]
-                )
+                mini_batch = {
+                    "input_ids": batch["input_ids"][idx : idx + self.config.mini_batch_size],
+                    "attention_mask": batch["attention_mask"][idx : idx + self.config.mini_batch_size]
+                }
+                mini_batch_queries, mini_batch_responses = self.get_inputs(mini_batch)
                 mini_batch_rewards = self.get_rewards(mini_batch_queries, mini_batch_responses)
                 queries.extend(mini_batch_queries)
                 responses.extend(mini_batch_responses)


### PR DESCRIPTION
# What does this PR do?

Fixes #6881

This PR fixes a bug in the PPO trainer's mini-batch handling where slicing operations could fail when `labels` are `None`. 

Previously, when passing the batch directly to `get_inputs()` using slice notation:
```python
mini_batch_queries, mini_batch_responses = self.get_inputs(
    batch[idx : idx + self.config.mini_batch_size]
)
```
This would attempt to slice all elements in the batch dictionary, including `labels` which could be `None`. The issue occurs because of how the transformers library handles dictionary slicing in `BatchEncoding.__getitem__`:

```python
def __getitem__(self, item: Union[int, str]) -> Union[Any, EncodingFast]:
    # ... 
    elif isinstance(item, slice):
        return {key: self.data[key][item] for key in self.data.keys()}  # This fails when data[key] is None
```

When a slice operation is performed, transformers attempts to apply the slice to every key in the dictionary. This raises an error when trying to slice a `None` value, as `None` does not support slice operations.

The fix modifies the code to explicitly create a new mini-batch dictionary with only the required fields (`input_ids` and `attention_mask`):
```python
mini_batch = {
    "input_ids": batch["input_ids"][idx : idx + self.config.mini_batch_size],
    "attention_mask": batch["attention_mask"][idx : idx + self.config.mini_batch_size]
}
mini_batch_queries, mini_batch_responses = self.get_inputs(mini_batch)
```

This change ensures that:
1. Only the necessary tensor fields are sliced
2. `None` values in the batch (like `labels`) are safely ignored
3. The PPO training process can continue without errors when labels are not provided
4. Avoids the transformers library's dictionary slicing limitation when handling `None` values

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?
