### PR TITLE
Qwen2Omni nit for video_grids

### DIFF
--- a/src/llamafactory/data/collator.py
+++ b/src/llamafactory/data/collator.py
@@ -192,6 +192,8 @@ class MultiModalDataCollatorForSeq2Seq(DataCollatorForSeq2Seq):
             }
             if "second_per_grid_ts" in mm_inputs:  # for qwen2vl
                 rope_index_kwargs["second_per_grid_ts"] = mm_inputs.get("second_per_grid_ts")
+            if "video_second_per_grid" in mm_inputs:  # for qwen2omni
+                rope_index_kwargs["second_per_grids"] = mm_inputs.get("video_second_per_grid")
 
             if getattr(self.model.config, "model_type", None) == "qwen2_5_omni_thinker":  # for qwen2omni
                 feature_attention_mask = mm_inputs.get("feature_attention_mask", None)

--- a/src/llamafactory/data/mm_plugin.py
+++ b/src/llamafactory/data/mm_plugin.py
@@ -1271,7 +1271,9 @@ class Qwen2OmniPlugin(Qwen2VLPlugin):
             )
             mm_inputs.update(image_processor(images=None, videos=video_dict["videos"], return_tensors="pt"))
             temporal_patch_size: int = getattr(image_processor, "temporal_patch_size", 2)
-            mm_inputs["video_second_per_grid"] = torch.tensor([temporal_patch_size / fps for fps in video_dict["fps_per_video"])])
+            mm_inputs["video_second_per_grid"] = torch.tensor(
+                [temporal_patch_size / fps for fps in video_dict["fps_per_video"]]
+            )
 
         if len(audios) != 0:
             audios = self._regularize_audios(


### PR DESCRIPTION
# What does this PR do?
Change some field names and fix the video SFT error.
## Test case with 2*V100 fp16
```yaml
### method
stage: sft
do_train: true
finetuning_type: lora
lora_rank: 8
lora_target: all

### dataset
dataset:  mllm_video_demo, mllm_demo, identity, mllm_audio_demo
cutoff_len: 3072
max_samples: 1000
overwrite_cache: true
```
![image](https://github.com/user-attachments/assets/48056b0c-17cd-4e64-adde-e642f8e25390)

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?
