### PR TITLE
"KeyError" bug fix 

### DIFF
--- a/src/llamafactory/train/dpo/workflow.py
+++ b/src/llamafactory/train/dpo/workflow.py
@@ -92,7 +92,7 @@ def run_dpo(
         trainer.save_state()
         if trainer.is_world_process_zero() and finetuning_args.plot_loss:
             keys = ["loss", "rewards/accuracies"]
-            if isinstance(dataset_module["eval_dataset"], dict):
+            if isinstance(dataset_module.get("eval_dataset"), dict):
                 keys += [f"eval_{key}_loss" for key in dataset_module["eval_dataset"].keys()]
             else:
                 keys += ["eval_loss"]

--- a/src/llamafactory/train/kto/workflow.py
+++ b/src/llamafactory/train/kto/workflow.py
@@ -83,7 +83,7 @@ def run_kto(
         trainer.save_state()
         if trainer.is_world_process_zero() and finetuning_args.plot_loss:
             keys = ["loss", "rewards/chosen"]
-            if isinstance(dataset_module["eval_dataset"], dict):
+            if isinstance(dataset_module.get("eval_dataset"), dict):
                 keys += [f"eval_{key}_loss" for key in dataset_module["eval_dataset"].keys()]
             else:
                 keys += ["eval_loss"]

--- a/src/llamafactory/train/pt/workflow.py
+++ b/src/llamafactory/train/pt/workflow.py
@@ -67,7 +67,7 @@ def run_pt(
         trainer.save_state()
         if trainer.is_world_process_zero() and finetuning_args.plot_loss:
             keys = ["loss"]
-            if isinstance(dataset_module["eval_dataset"], dict):
+            if isinstance(dataset_module.get("eval_dataset"), dict):
                 keys += [f"eval_{key}_loss" for key in dataset_module["eval_dataset"].keys()]
             else:
                 keys += ["eval_loss"]

--- a/src/llamafactory/train/rm/workflow.py
+++ b/src/llamafactory/train/rm/workflow.py
@@ -75,7 +75,7 @@ def run_rm(
         trainer.save_state()
         if trainer.is_world_process_zero() and finetuning_args.plot_loss:
             keys = ["loss"]
-            if isinstance(dataset_module["eval_dataset"], dict):
+            if isinstance(dataset_module.get("eval_dataset"), dict):
                 keys += sum(
                     [[f"eval_{key}_loss", f"eval_{key}_accuracy"] for key in dataset_module["eval_dataset"].keys()], []
                 )

--- a/src/llamafactory/train/sft/workflow.py
+++ b/src/llamafactory/train/sft/workflow.py
@@ -111,7 +111,7 @@ def run_sft(
         trainer.save_state()
         if trainer.is_world_process_zero() and finetuning_args.plot_loss:
             keys = ["loss"]
-            if isinstance(dataset_module["eval_dataset"], dict):
+            if isinstance(dataset_module.get("eval_dataset"), dict):
                 keys += sum(
                     [[f"eval_{key}_loss", f"eval_{key}_accuracy"] for key in dataset_module["eval_dataset"].keys()], []
                 )


### PR DESCRIPTION
# What does this PR do?

Fixing `"KeyError"` issue when dataset_module does not contain the `"eval_dataset"` key.

Changing `dataset_module["eval_dataset"]` to `dataset_module.get("eval_dataset")` can fix this, `dataset_module.get("eval_dataset")` will return `None` when dataset_module does not contain the `"eval_dataset"` key, but `dataset_module["eval_dataset"]` will lead to broken error like: 

```
[rank0]: Traceback (most recent call last):
[rank0]:   File "/rofunc/LLaMA-Factory/src/llamafactory/launcher.py", line 23, in <module>
[rank0]:     launch()
[rank0]:   File "/rofunc/LLaMA-Factory/src/llamafactory/launcher.py", line 19, in launch
[rank0]:     run_exp()
[rank0]:   File "/rofunc/LLaMA-Factory/src/llamafactory/train/tuner.py", line 107, in run_exp
[rank0]:     _training_function(config={"args": args, "callbacks": callbacks})
[rank0]:   File "/rofunc/LLaMA-Factory/src/llamafactory/train/tuner.py", line 69, in _training_function
[rank0]:     run_sft(model_args, data_args, training_args, finetuning_args, generating_args, callbacks)
[rank0]:   File "/rofunc/LLaMA-Factory/src/llamafactory/train/sft/workflow.py", line 114, in run_sft
[rank0]:     if isinstance(dataset_module["eval_dataset"], dict):
[rank0]: KeyError: 'eval_dataset'
```

The "workflow.py" files in "dpo", "kto", "pt", "rm", "sft" may meet this issue; all of them were fixed.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
