### PR TITLE
Allow for specifying ray.init kwargs (i.e. runtime_env)

### DIFF
--- a/examples/train_lora/llama3_lora_sft_ray.yaml
+++ b/examples/train_lora/llama3_lora_sft_ray.yaml
@@ -30,13 +30,11 @@ report_to: none  # choices: [none, wandb, tensorboard, swanlab, mlflow]
 
 ### ray
 ray_run_name: llama3_8b_sft_lora
-ray_storage_path: /mnt/cluster_storage/
-ray_num_workers: 8  # Number of GPUs to use.
+ray_storage_path: ./saves
+ray_num_workers: 4  # Number of GPUs to use.
+placement_strategy: PACK
 resources_per_worker:
   GPU: 1
-  anyscale/accelerator_shape:4xL4: 0.001  # Use this to specify a specific node shape.
-  # accelerator_type:L4: 0.001            # Or use this to simply specify a GPU type.
-  # See https://docs.ray.io/en/master/ray-core/accelerator-types.html#accelerator-types for a full list of accelerator types.
 # ray_init_kwargs:
 #   runtime_env:
 #     env_vars:

--- a/examples/train_lora/llama3_lora_sft_ray.yaml
+++ b/examples/train_lora/llama3_lora_sft_ray.yaml
@@ -30,11 +30,19 @@ report_to: none  # choices: [none, wandb, tensorboard, swanlab, mlflow]
 
 ### ray
 ray_run_name: llama3_8b_sft_lora
-ray_storage_path: ./saves
-ray_num_workers: 4  # number of GPUs to use
+ray_storage_path: /mnt/cluster_storage/
+ray_num_workers: 8  # Number of GPUs to use.
 resources_per_worker:
   GPU: 1
-placement_strategy: PACK
+  anyscale/accelerator_shape:4xL4: 0.001  # Use this to specify a specific node shape.
+  # accelerator_type:L4: 0.001            # Or use this to simply specify a GPU type.
+  # See https://docs.ray.io/en/master/ray-core/accelerator-types.html#accelerator-types for a full list of accelerator types.
+# ray_init_kwargs:
+#   runtime_env:
+#     env_vars:
+#       <YOUR-ENV-VAR-HERE>: "<YOUR-ENV-VAR-HERE>"
+#     pip:
+#       - emoji
 
 ### train
 per_device_train_batch_size: 1

--- a/src/llamafactory/hparams/training_args.py
+++ b/src/llamafactory/hparams/training_args.py
@@ -46,6 +46,10 @@ class RayArguments:
         default="PACK",
         metadata={"help": "The placement strategy for Ray training. Default is PACK."},
     )
+    ray_init_kwargs: Optional[dict] = field(
+        default=None,
+        metadata={"help": "The arguments to pass to ray.init for Ray training. Default is None."},
+    )
 
     def __post_init__(self):
         self.use_ray = use_ray()

--- a/src/llamafactory/train/trainer_utils.py
+++ b/src/llamafactory/train/trainer_utils.py
@@ -643,6 +643,10 @@ def get_ray_trainer(
 ) -> "TorchTrainer":
     if not ray_args.use_ray:
         raise ValueError("Ray was not enabled. Please set `USE_RAY=1` to enable ray.")
+    if ray_args.ray_init_kwargs is not None:
+        import ray
+
+        ray.init(**ray_args.ray_init_kwargs)
 
     trainer = TorchTrainer(
         training_function,


### PR DESCRIPTION
# What does this PR do?

Fixes #7598 

Allows the user to specify kwargs for calling ray.init - for example:

```yaml
...
 ray_init_kwargs:
   runtime_env:
    env_vars:
      <YOUR-ENV-VAR-HERE>: "<YOUR-ENV-VAR-HERE>"
     pip:
       - emoji
...
```

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
