### PR TITLE
支持 GLM-4-0414 模型

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Compared to ChatGLM's [P-Tuning](https://github.com/THUDM/ChatGLM2-6B/tree/main/
 | [Falcon](https://huggingface.co/tiiuae)                           | 7B/11B/40B/180B                  | falcon              |
 | [Gemma/Gemma 2/CodeGemma](https://huggingface.co/google)          | 2B/7B/9B/27B                     | gemma               |
 | [Gemma 3](https://huggingface.co/google)                          | 1B/4B/12B/27B                    | gemma3/gemma (1B)   |
-| [GLM-4](https://huggingface.co/THUDM)                             | 9B                               | glm4                |
+| [GLM-4/GLM-4-0414](https://huggingface.co/THUDM)                  | 9B/32B                           | glm4                |
 | [GPT-2](https://huggingface.co/openai-community)                  | 0.1B/0.4B/0.8B/1.5B              | -                   |
 | [Granite 3.0-3.1](https://huggingface.co/ibm-granite)             | 1B/2B/3B/8B                      | granite3            |
 | [Index](https://huggingface.co/IndexTeam)                         | 1.9B                             | index               |

--- a/README_zh.md
+++ b/README_zh.md
@@ -242,8 +242,7 @@ https://github.com/user-attachments/assets/43b700c6-a178-41db-b1f8-8190a5d3fcfc
 | [Falcon](https://huggingface.co/tiiuae)                           | 7B/11B/40B/180B                  | falcon              |
 | [Gemma/Gemma 2/CodeGemma](https://huggingface.co/google)          | 2B/7B/9B/27B                     | gemma               |
 | [Gemma 3](https://huggingface.co/google)                          | 1B/4B/12B/27B                    | gemma3/gemma (1B)   |
-| [GLM-4](https://huggingface.co/THUDM)                             | 9B                               | glm4                |
-| [GLM-4-0414](https://huggingface.co/THUDM)                        | 9B/32B                           | glm4                |
+| [GLM-4/GLM-4-0414](https://huggingface.co/THUDM)                  | 9B/32B                           | glm4                |
 | [GPT-2](https://huggingface.co/openai-community)                  | 0.1B/0.4B/0.8B/1.5B              | -                   |
 | [Granite 3.0-3.1](https://huggingface.co/ibm-granite)             | 1B/2B/3B/8B                      | granite3            |
 | [Hunyuan](https://huggingface.co/tencent/)                        | 7B                               | hunyuan             |

--- a/README_zh.md
+++ b/README_zh.md
@@ -243,6 +243,7 @@ https://github.com/user-attachments/assets/43b700c6-a178-41db-b1f8-8190a5d3fcfc
 | [Gemma/Gemma 2/CodeGemma](https://huggingface.co/google)          | 2B/7B/9B/27B                     | gemma               |
 | [Gemma 3](https://huggingface.co/google)                          | 1B/4B/12B/27B                    | gemma3/gemma (1B)   |
 | [GLM-4](https://huggingface.co/THUDM)                             | 9B                               | glm4                |
+| [GLM-4-0414](https://huggingface.co/THUDM)                        | 9B/32B                           | glm4                |
 | [GPT-2](https://huggingface.co/openai-community)                  | 0.1B/0.4B/0.8B/1.5B              | -                   |
 | [Granite 3.0-3.1](https://huggingface.co/ibm-granite)             | 1B/2B/3B/8B                      | granite3            |
 | [Hunyuan](https://huggingface.co/tencent/)                        | 7B                               | hunyuan             |

--- a/src/llamafactory/extras/constants.py
+++ b/src/llamafactory/extras/constants.py
@@ -724,6 +724,26 @@ register_model_group(
             DownloadSource.DEFAULT: "THUDM/glm-4-9b-chat-1m",
             DownloadSource.MODELSCOPE: "ZhipuAI/glm-4-9b-chat-1m",
         },
+        "GLM-4-9B-Chat-0414": {
+            DownloadSource.DEFAULT: "THUDM/GLM-4-9B-Chat-0414",
+            DownloadSource.MODELSCOPE: "ZhipuAI/GLM-4-9B-Chat-0414" ,
+        },
+        "GLM-4-32B-0414": {
+            DownloadSource.DEFAULT: "THUDM/GLM-4-32B-0414",
+            DownloadSource.MODELSCOPE: "ZhipuAI/GLM-4-32B-0414" ,
+        },
+        "GLM-4-32B-Chat-0414": {
+            DownloadSource.DEFAULT: "THUDM/GLM-4-32B-Chat-0414",
+            DownloadSource.MODELSCOPE: "ZhipuAI/GLM-4-32B-Chat-0414" ,
+        },
+        "GLM-4-Z1-9B-0414": {
+            DownloadSource.DEFAULT: "THUDM/GLM-4-Z1-9B-0414",
+            DownloadSource.MODELSCOPE: "ZhipuAI/GLM-4-Z1-9B-0414" ,
+        },
+        "GLM-4-Z1-32B-0414": {
+            DownloadSource.DEFAULT: "THUDM/GLM-4-Z1-32B-0414",
+            DownloadSource.MODELSCOPE: "ZhipuAI/GLM-4-Z1-32B-0414" ,
+        },
     },
     template="glm4",
 )


### PR DESCRIPTION
框架可以直接支持即将发布的`GLM-4-0414` 模型（不考虑数据构建情况）

+ `chat_template` 不使用 Function Call 和 思维链方式和框架中`glm4`类相同。
+  需要在`src/llamafactory/extras/misc.py`支持`transformers`当前主分支（或者下一个版本）才能支持该模型，否则`transformers`无法读取到`GLM4`类。

例如:
```
check_version("transformers>=4.41.2,<=4.52.0dev,!=4.46.0,!=4.46.1,!=4.46.2,!=4.46.3,!=4.47.0,!=4.47.1,!=4.48.0")
```
