### PR TITLE
Patch docker-rocm

### DIFF
--- a/docker/docker-rocm/Dockerfile
+++ b/docker/docker-rocm/Dockerfile
@@ -64,7 +64,10 @@ RUN EXTRA_PACKAGES="metrics"; \
         pip install -e ".[$EXTRA_PACKAGES]"; \
     fi
 
-RUN if [ "$INSTALL_PYTORCH" == "true" ]; then \
+# Reinstall pytorch
+# This is necessary to ensure that the correct version of PyTorch is installed
+RUN if [ "$INSTALL_PYTORCH" = "true" ]; then \
+        pip uninstall -y torch torchvision torchaudio && \
         pip install --pre torch torchvision torchaudio --index-url "$PYTORCH_INDEX"; \
     fi
 

--- a/docker/docker-rocm/Dockerfile
+++ b/docker/docker-rocm/Dockerfile
@@ -12,8 +12,10 @@ ARG INSTALL_DEEPSPEED=false
 ARG INSTALL_FLASHATTN=false
 ARG INSTALL_LIGER_KERNEL=false
 ARG INSTALL_HQQ=false
+ARG INSTALL_PYTORCH=true
 ARG PIP_INDEX=https://pypi.org/simple
 ARG HTTP_PROXY=
+ARG PYTORCH_INDEX=https://download.pytorch.org/whl/nightly/rocm6.3
 
 # Set the working directory
 WORKDIR /app
@@ -61,6 +63,10 @@ RUN EXTRA_PACKAGES="metrics"; \
     else \
         pip install -e ".[$EXTRA_PACKAGES]"; \
     fi
+
+RUN if [ "$INSTALL_PYTORCH" == "true" ]; then \
+        pip install --pre torch torchvision torchaudio --index-url "$PYTORCH_INDEX"; \
+    fi; \
 
 # Rebuild flash attention
 RUN pip uninstall -y transformer-engine flash-attn && \

--- a/docker/docker-rocm/Dockerfile
+++ b/docker/docker-rocm/Dockerfile
@@ -17,6 +17,9 @@ ARG PIP_INDEX=https://pypi.org/simple
 ARG HTTP_PROXY=
 ARG PYTORCH_INDEX=https://download.pytorch.org/whl/nightly/rocm6.3
 
+# Use Bash instead of default /bin/sh
+SHELL ["/bin/bash", "-c"]
+
 # Set the working directory
 WORKDIR /app
 
@@ -66,7 +69,7 @@ RUN EXTRA_PACKAGES="metrics"; \
 
 # Reinstall pytorch
 # This is necessary to ensure that the correct version of PyTorch is installed
-RUN if [ "$INSTALL_PYTORCH" = "true" ]; then \
+RUN if [ "$INSTALL_PYTORCH" == "true" ]; then \
         pip uninstall -y torch torchvision torchaudio && \
         pip install --pre torch torchvision torchaudio --index-url "$PYTORCH_INDEX"; \
     fi

--- a/docker/docker-rocm/Dockerfile
+++ b/docker/docker-rocm/Dockerfile
@@ -66,7 +66,7 @@ RUN EXTRA_PACKAGES="metrics"; \
 
 RUN if [ "$INSTALL_PYTORCH" == "true" ]; then \
         pip install --pre torch torchvision torchaudio --index-url "$PYTORCH_INDEX"; \
-    fi; \
+    fi
 
 # Rebuild flash attention
 RUN pip uninstall -y transformer-engine flash-attn && \

--- a/docker/docker-rocm/docker-compose.yml
+++ b/docker/docker-rocm/docker-compose.yml
@@ -9,8 +9,10 @@ services:
         INSTALL_DEEPSPEED: "false"
         INSTALL_FLASHATTN: "false"
         INSTALL_LIGER_KERNEL: "false"
+        INSTALL_PYTORCH: "true"
         INSTALL_HQQ: "false"
         PIP_INDEX: https://pypi.org/simple
+        PYTORCH_INDEX: https://download.pytorch.org/whl/nightly/rocm6.3
     container_name: llamafactory
     volumes:
       - ../../hf_cache:/root/.cache/huggingface


### PR DESCRIPTION
# What does this PR do?
This PR brings in patches for the `docker/docker-rocm` : 
* The shell is set to `/bin/bash` - this is needed for evaluation of string comparisons; currently these fail (silently) to execute in the default `/bin/sh` shell
* This adds an optional build argument to reinstall pytorch, potentially from the nightly builds; This is beneficial for some users (e.g. see Issue #5716) where pytorch built against ROCm 6.3 is needed to avoid segmentation fault (and `grad_norm=nan` in full training)


Fixes # 5716

## Before submitting

- [ X ] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests? N/A
