### PR TITLE
[data] Fix wrong position ids with packed attention masks

### DIFF
--- a/src/llamafactory/data/collator.py
+++ b/src/llamafactory/data/collator.py
@@ -176,7 +176,7 @@ class MultiModalDataCollatorForSeq2Seq(DataCollatorForSeq2Seq):
                 "input_ids": features["input_ids"],
                 "image_grid_thw": mm_inputs.get("image_grid_thw"),
                 "video_grid_thw": mm_inputs.get("video_grid_thw"),
-                "attention_mask": features["attention_mask"],
+                "attention_mask": (features["attention_mask"] >= 1).float(),
             }
             if "second_per_grid_ts" in mm_inputs:  # for qwen2vl
                 rope_index_kwargs["second_per_grid_ts"] = mm_inputs.get("second_per_grid_ts")
@@ -200,7 +200,6 @@ class MultiModalDataCollatorForSeq2Seq(DataCollatorForSeq2Seq):
                     rope_deltas - delta0,
                 )  # avoid inplace operation FIXME
             else:  # for qwen2vl
-                rope_index_kwargs["attention_mask"] = (rope_index_kwargs["attention_mask"] >= 1).float()
                 features["position_ids"], features["rope_deltas"] = self.model.get_rope_index(**rope_index_kwargs)
 
         if "cross_attention_mask" in mm_inputs:  # for mllama inputs when pad_to_multiple_of is enabled

--- a/src/llamafactory/data/collator.py
+++ b/src/llamafactory/data/collator.py
@@ -200,6 +200,7 @@ class MultiModalDataCollatorForSeq2Seq(DataCollatorForSeq2Seq):
                     rope_deltas - delta0,
                 )  # avoid inplace operation FIXME
             else:  # for qwen2vl
+                rope_index_kwargs["attention_mask"] = (rope_index_kwargs["attention_mask"] >= 1).float()
                 features["position_ids"], features["rope_deltas"] = self.model.get_rope_index(**rope_index_kwargs)
 
         if "cross_attention_mask" in mm_inputs:  # for mllama inputs when pad_to_multiple_of is enabled


### PR DESCRIPTION
# What does this PR do?

in the `get_rope_index` of qwen2vl, it only considers the attention masks with value 1. 

https://github.com/huggingface/transformers/blob/dc06e7cecd5dc98681566e5201481b42583c4382/src/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py#L1682

But if we use the neat packing, the attention mask looks like `[1, 1, 2, 2, 2, 0]`, which yields a wrong position id for the second sentence.

I think this is related to #5426 

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
