### PR TITLE
Fixing QuantizationMethod.BITS_AND_BYTES to QuantizationMethod.BNB

### DIFF
--- a/src/llamafactory/model/adapter.py
+++ b/src/llamafactory/model/adapter.py
@@ -204,7 +204,7 @@ def _setup_lora_tuning(
         if (
             finetuning_args.use_dora
             and getattr(model, "quantization_method", None) is not None
-            and getattr(model, "quantization_method", None) != QuantizationMethod.BITS_AND_BYTES
+            and getattr(model, "quantization_method", None) != QuantizationMethod.BNB
         ):
             raise ValueError("DoRA is not compatible with PTQ-quantized models.")
 

--- a/src/llamafactory/webui/control.py
+++ b/src/llamafactory/webui/control.py
@@ -56,7 +56,7 @@ def can_quantize_to(quantization_method: str) -> "gr.Dropdown":
     Inputs: top.quantization_method
     Outputs: top.quantization_bit
     """
-    if quantization_method == QuantizationMethod.BITS_AND_BYTES.value:
+    if quantization_method == QuantizationMethod.BNB.value:
         available_bits = ["none", "8", "4"]
     elif quantization_method == QuantizationMethod.HQQ.value:
         available_bits = ["none", "8", "6", "5", "4", "3", "2", "1"]


### PR DESCRIPTION
# What does this PR do?

Fixes #7688
Issues where `QuantizationMethod.BITS_AND_BYTES` was used instead of  `QuantizationMethod.BNB`, updated to fix this.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
