### PR TITLE
fix Gemma export

### DIFF
--- a/src/llamafactory/model/model_utils/quantization.py
+++ b/src/llamafactory/model/model_utils/quantization.py
@@ -128,15 +128,16 @@ def configure_quantization(
                 gq_utils.BLOCK_PATTERNS.insert(0, "language_model.model.layers")
         except ImportError:
             pass
-        block_name = None
-        if getattr(config, "model_type", None) in ["gemma", "paligemma"]:
-            block_name = "language_model.model.layers"
+
+        block_name_to_quantize = None
+        if getattr(config, "model_type", None) in ["gemma3", "paligemma"]:
+            block_name_to_quantize = "language_model.model.layers"
 
         init_kwargs["quantization_config"] = GPTQConfig(
             bits=model_args.export_quantization_bit,
             tokenizer=tokenizer,
             dataset=_get_quantization_dataset(tokenizer, model_args),
-            block_name_to_quantize=block_name,
+            block_name_to_quantize=block_name_to_quantize,
         )
         init_kwargs["device_map"] = "auto"
         init_kwargs["max_memory"] = get_max_memory()

--- a/src/llamafactory/model/model_utils/quantization.py
+++ b/src/llamafactory/model/model_utils/quantization.py
@@ -122,9 +122,21 @@ def configure_quantization(
         if getattr(config, "model_type", None) == "chatglm":
             raise ValueError("ChatGLM model is not supported yet.")
 
+        try:
+            from optimum.gptq import utils as gq_utils
+            if "language_model.model.layers" not in gq_utils.BLOCK_PATTERNS:
+                gq_utils.BLOCK_PATTERNS.insert(0, "language_model.model.layers")
+        except ImportError:
+            pass
+        block_name = None
+        if getattr(config, "model_type", None) in ["gemma", "paligemma"]:
+            block_name = "language_model.model.layers"
+
         init_kwargs["quantization_config"] = GPTQConfig(
             bits=model_args.export_quantization_bit,
+            tokenizer=tokenizer,
             dataset=_get_quantization_dataset(tokenizer, model_args),
+            block_name_to_quantize=block_name,
         )
         init_kwargs["device_map"] = "auto"
         init_kwargs["max_memory"] = get_max_memory()


### PR DESCRIPTION
# What does this PR do?

fix Gemma export

Fixes # 
[INFO|configuration_utils.py:1095] 2025-04-20 23:52:16,965 >> loading configuration file google/gemma-3-4b-it\generation_config.json 
[INFO|configuration_utils.py:1142] 2025-04-20 23:52:16,965 >> Generate config GenerationConfig {
  "bos_token_id": 2,
  "cache_implementation": "hybrid",
  "do_sample": true,
  "eos_token_id": [
    1,
    106
  ],
  "pad_token_id": 0,
  "top_k": 64,
  "top_p": 0.95
}

Traceback (most recent call last):
  File "C:\Users\user\AppData\Local\Programs\Python\Python310\lib\site-packages\gradio\queueing.py", line 715, in process_events
    response = await route_utils.call_process_api(
  File "C:\Users\user\AppData\Local\Programs\Python\Python310\lib\site-packages\gradio\route_utils.py", line 322, in call_process_api
    output = await app.get_blocks().process_api(
  File "C:\Users\user\AppData\Local\Programs\Python\Python310\lib\site-packages\gradio\blocks.py", line 2137, in process_api
    result = await self.call_function(
  File "C:\Users\user\AppData\Local\Programs\Python\Python310\lib\site-packages\gradio\blocks.py", line 1675, in call_function
    prediction = await utils.async_iteration(iterator)
  File "C:\Users\user\AppData\Local\Programs\Python\Python310\lib\site-packages\gradio\utils.py", line 735, in async_iteration
    return await anext(iterator)
  File "C:\Users\user\AppData\Local\Programs\Python\Python310\lib\site-packages\gradio\utils.py", line 729, in __anext__
    return await anyio.to_thread.run_sync(
  File "C:\Users\user\AppData\Local\Programs\Python\Python310\lib\site-packages\anyio\to_thread.py", line 56, in run_sync
    return await get_async_backend().run_sync_in_worker_thread(
  File "C:\Users\user\AppData\Local\Programs\Python\Python310\lib\site-packages\anyio\_backends\_asyncio.py", line 2470, in run_sync_in_worker_thread
    return await future
  File "C:\Users\user\AppData\Local\Programs\Python\Python310\lib\site-packages\anyio\_backends\_asyncio.py", line 967, in run
    result = context.run(func, *args)
  File "C:\Users\user\AppData\Local\Programs\Python\Python310\lib\site-packages\gradio\utils.py", line 712, in run_sync_iterator_async
    return next(iterator)
  File "C:\Users\user\AppData\Local\Programs\Python\Python310\lib\site-packages\gradio\utils.py", line 873, in gen_wrapper
    response = next(iterator)
  File "C:\Temp\1\3_train_model\llamma_factory\LLaMA-Factory\src\llamafactory\webui\components\export.py", line 105, in save_model
    export_model(args)
  File "C:\Temp\1\3_train_model\llamma_factory\LLaMA-Factory\src\llamafactory\train\tuner.py", line 123, in export_model
    model = load_model(tokenizer, model_args, finetuning_args)  # must after fixing tokenizer to resize vocab
  File "C:\Temp\1\3_train_model\llamma_factory\LLaMA-Factory\src\llamafactory\model\loader.py", line 167, in load_model
    model = load_class.from_pretrained(**init_kwargs)
  File "C:\Users\user\AppData\Local\Programs\Python\Python310\lib\site-packages\transformers\models\auto\auto_factory.py", line 571, in from_pretrained
    return model_class.from_pretrained(
  File "C:\Users\user\AppData\Local\Programs\Python\Python310\lib\site-packages\transformers\modeling_utils.py", line 279, in _wrapper
    return func(*args, **kwargs)
  File "C:\Users\user\AppData\Local\Programs\Python\Python310\lib\site-packages\transformers\modeling_utils.py", line 4478, in from_pretrained
    hf_quantizer.postprocess_model(model, config=config)
  File "C:\Users\user\AppData\Local\Programs\Python\Python310\lib\site-packages\transformers\quantizers\base.py", line 238, in postprocess_model
    return self._process_model_after_weight_loading(model, **kwargs)
  File "C:\Users\user\AppData\Local\Programs\Python\Python310\lib\site-packages\transformers\quantizers\quantizer_gptq.py", line 116, in _process_model_after_weight_loading
    self.optimum_quantizer.quantize_model(model, self.quantization_config.tokenizer)
  File "C:\Users\user\AppData\Local\Programs\Python\Python310\lib\site-packages\torch\utils\_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
  File "C:\Users\user\AppData\Local\Programs\Python\Python310\lib\site-packages\optimum\gptq\quantizer.py", line 515, in quantize_model
    self.block_name_to_quantize = get_block_name_with_pattern(model)
  File "C:\Users\user\AppData\Local\Programs\Python\Python310\lib\site-packages\optimum\gptq\utils.py", line 77, in get_block_name_with_pattern
    raise ValueError("Block pattern could not be match. Pass block_name_to_quantize argument in quantize_model")
ValueError: Block pattern could not be match. Pass block_name_to_quantize argument in quantize_model


## Before submitting

- [] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [] Did you write any new necessary tests?
[INFO|configuration_utils.py:1142] 2025-04-21 01:01:08,258 >> Generate config GenerationConfig {
  "bos_token_id": 2,
  "cache_implementation": "hybrid",
  "do_sample": true,
  "eos_token_id": [
    1,
    106
  ],
  "pad_token_id": 0,
  "top_k": 64,
  "top_p": 0.95
}

Quantizing language_model.model.layers blocks :   0%|                                                                         | 0/34 [00:00<?, ?it/s]
Quantizing layers inside the block:  57%|████████████████████████████████████████████▌                                 | 4/7 [00:50<00:32, 10.71s/it]