### PR TITLE
[data] Avoid repetitive tool description warp

### DIFF
--- a/src/llamafactory/data/tool_utils.py
+++ b/src/llamafactory/data/tool_utils.py
@@ -93,6 +93,7 @@ class DefaultToolUtils(ToolUtils):
         tool_text = ""
         tool_names = []
         for tool in tools:
+            tool = tool.get("function", "") if tool.get("type") == "function" else tool
             param_text = ""
             for name, param in tool["parameters"]["properties"].items():
                 required, enum, items = "", "", ""
@@ -159,6 +160,7 @@ class GLM4ToolUtils(ToolUtils):
     def tool_formatter(tools: list[dict[str, Any]]) -> str:
         tool_text = ""
         for tool in tools:
+            tool = tool.get("function", "") if tool.get("type") == "function" else tool
             tool_text += "\n\n## {name}\n\n{body}\n在调用上述函数时，请使用 Json 格式表示调用的参数。".format(
                 name=tool["name"], body=json.dumps(tool, indent=4, ensure_ascii=False)
             )
@@ -200,10 +202,7 @@ class Llama3ToolUtils(ToolUtils):
         date = datetime.now().strftime("%d %b %Y")
         tool_text = ""
         for tool in tools:
-            if tool.get("type") == "function" and tool.get("function"):
-                wrapped_tool = tool
-            else:
-                wrapped_tool = {"type": "function", "function": tool}
+            wrapped_tool = tool if tool.get("type") == "function" else {"type": "function", "function": tool}
             tool_text += json.dumps(wrapped_tool, indent=4, ensure_ascii=False) + "\n\n"
 
         return LLAMA3_TOOL_PROMPT.format(date=date, tool_text=tool_text)
@@ -238,10 +237,9 @@ class MistralToolUtils(ToolUtils):
     def tool_formatter(tools: list[dict[str, Any]]) -> str:
         wrapped_tools = []
         for tool in tools:
-            if tool.get("type") == "function" and tool.get("function"):
-                wrapped_tools.append(tool)
-            else:
-                wrapped_tools.append({"type": "function", "function": tool})
+            wrapped_tools.append(
+                tool if tool.get("type") == "function" else {"type": "function", "function": tool}
+            )
 
         return "[AVAILABLE_TOOLS] " + json.dumps(wrapped_tools, ensure_ascii=False) + "[/AVAILABLE_TOOLS]"
 
@@ -283,10 +281,7 @@ class QwenToolUtils(ToolUtils):
     def tool_formatter(tools: list[dict[str, Any]]) -> str:
         tool_text = ""
         for tool in tools:
-            if tool.get("type") == "function" and tool.get("function"):
-                wrapped_tool = tool
-            else:
-                wrapped_tool = {"type": "function", "function": tool}
+            wrapped_tool = tool if tool.get("type") == "function" else {"type": "function", "function": tool}
             tool_text += "\n" + json.dumps(wrapped_tool, ensure_ascii=False)
 
         return QWEN_TOOL_PROMPT.format(tool_text=tool_text)


### PR DESCRIPTION
# What does this PR do?

Currently, ToolUtils wraps the tool description automatically like this: `{"type": "function", "function": tool}`. 
This PR aims to check tool format before wrapping.

Fixes # (issue)

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?
