### PR TITLE
feat: add smollm support

### DIFF
--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -1672,6 +1672,21 @@ register_template(
 
 
 register_template(
+    name="smollm",
+    format_system=StringFormatter(
+        slots=["<|im_start|>system\n{{content}}<|im_end|>\n"]
+    ),
+    format_user=StringFormatter(
+        slots=["<|im_start|>user\n{{content}}<|im_end|>\n"]
+    ),
+    format_assistant=StringFormatter(
+        slots=["<|im_start|>assistant\n{{content}}<|im_end|>\n"]
+    ),
+    stop_words=["<|im_end|>"],
+)
+
+
+register_template(
     name="solar",
     format_user=StringFormatter(slots=["### User:\n{{content}}\n\n### Assistant:\n"]),
     format_system=StringFormatter(slots=["### System:\n{{content}}\n\n"]),

--- a/src/llamafactory/extras/constants.py
+++ b/src/llamafactory/extras/constants.py
@@ -2713,6 +2713,25 @@ register_model_group(
 
 register_model_group(
     models={
+        "SmolLM-135M-Instruct": {
+            DownloadSource.DEFAULT: "HuggingFaceTB/SmolLM-135M-Instruct",
+            DownloadSource.MODELSCOPE: "HuggingFaceTB/SmolLM-135M-Instruct",
+        },
+        "SmolLM-360M-Instruct": {
+            DownloadSource.DEFAULT: "HuggingFaceTB/SmolLM-360M-Instruct",
+            DownloadSource.MODELSCOPE: "HuggingFaceTB/SmolLM-360M-Instruct",
+        },
+        "SmolLM-1.7B-Instruct": {
+            DownloadSource.DEFAULT: "HuggingFaceTB/SmolLM-1.7B-Instruct",
+            DownloadSource.MODELSCOPE: "HuggingFaceTB/SmolLM-1.7B-Instruct",
+        },
+    },
+    template="smollm",
+)
+
+
+register_model_group(
+    models={
         "SOLAR-10.7B-v1.0": {
             DownloadSource.DEFAULT: "upstage/SOLAR-10.7B-v1.0",
         },


### PR DESCRIPTION
# What does this PR do?

This PR adds support for the SmolLM model series by registering a new template ("smollm") and model group, incorporating three model variants: SmolLM-135M-Instruct, SmolLM-360M-Instruct, and SmolLM-1.7B-Instruct.
