### PR TITLE
[workflow] fix KeyError at end of pretrain.

### DIFF
--- a/src/llamafactory/train/pt/workflow.py
+++ b/src/llamafactory/train/pt/workflow.py
@@ -77,12 +77,22 @@ def run_pt(
     # Evaluation
     if training_args.do_eval:
         metrics = trainer.evaluate(metric_key_prefix="eval")
-        try:
-            perplexity = math.exp(metrics["eval_loss"])
-        except OverflowError:
-            perplexity = float("inf")
 
-        metrics["perplexity"] = perplexity
+        if isinstance(dataset_module.get("eval_dataset"), dict):
+            for key in dataset_module["eval_dataset"].keys():
+                try:
+                    perplexity = math.exp(metrics[f"eval_{key}_loss"])
+                except OverflowError:
+                    perplexity = float("inf")
+                metrics[f"eval_{key}_perplexity"] = perplexity
+        else:
+            try:
+                perplexity = math.exp(metrics["eval_loss"])
+            except OverflowError:
+                perplexity = float("inf")
+            metrics["eval_perplexity"] = perplexity
+
+
         trainer.log_metrics("eval", metrics)
         trainer.save_metrics("eval", metrics)
 


### PR DESCRIPTION
# What does this PR do?

Fixes #8096 
- caused when using eval_on_each_data_set
- caused by: eval_loss & eval_{key}_loss
## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests? 

I tested offline with the following yaml:
```yaml
### model
model_name_or_path: /mnt/public/data/lh/models/Qwen2.5-0.5B

### Monitor
report_to: wandb

### method
stage: pt
do_train: true
finetuning_type: full
lora_target: all

### dataset
dataset_dir: /mnt/public/data/lh/xiaochen/workspace/dataflow_pt/dataset/
dataset: medical_guidelines
cutoff_len: 2048
preprocessing_num_workers: 128

### output
output_dir: ./saves/Qwen2.5-0.5B/train_pt_medical_Qwen2.5-0.5B_ds2_epochs_1_datasets_old10b_wgsm8k_try_separate
logging_steps: 10
save_steps: 2000
plot_loss: true
overwrite_output_dir: true

### train
deepspeed: /mnt/public/data/lh/xiaochen/workspace/LLaMA-Factory/examples/deepspeed/ds_z2_config.json
per_device_train_batch_size: 8
gradient_accumulation_steps: 4
learning_rate: 5.0e-5
num_train_epochs: 1
lr_scheduler_type: cosine
warmup_ratio: 0.1
bf16: true
ddp_timeout: 180000000

### eval
do_eval: true
eval_dataset: test_bioasq,test_gsm8k
per_device_eval_batch_size: 8
eval_strategy: steps
eval_on_each_dataset: true
eval_steps: 10
```

With the final correct output as:
```
{'eval_test_gsm8k_loss': 1.1564382314682007, 'eval_test_gsm8k_runtime': 7.2756, 'eval_test_gsm8k_samples_per_second': 259.496, 'eval_test_gsm8k_steps_per_second': 4.123, 'epoch': 1.0}                                                                           
100%|██████████████████████████████████████████████████████████████████████████████████████████| 170/170 [17:28<00:00,  3.90s/it[INFO|trainer.py:3910] 2025-05-19 14:03:50,209 >> Saving model checkpoint to ./saves/Qwen2.5-0.5B/train_pt_medical_Qwen2.5-0.5B_ds2_epochs_1_datasets_old10b_wgsm8k_try_separate/checkpoint-170
[INFO|configuration_utils.py:420] 2025-05-19 14:03:50,217 >> Configuration saved in ./saves/Qwen2.5-0.5B/train_pt_medical_Qwen2.5-0.5B_ds2_epochs_1_datasets_old10b_wgsm8k_try_separate/checkpoint-170/config.json
[INFO|configuration_utils.py:909] 2025-05-19 14:03:50,221 >> Configuration saved in ./saves/Qwen2.5-0.5B/train_pt_medical_Qwen2.5-0.5B_ds2_epochs_1_datasets_old10b_wgsm8k_try_separate/checkpoint-170/generation_config.json
[INFO|modeling_utils.py:2988] 2025-05-19 14:03:53,363 >> Model weights saved in ./saves/Qwen2.5-0.5B/train_pt_medical_Qwen2.5-0.5B_ds2_epochs_1_datasets_old10b_wgsm8k_try_separate/checkpoint-170/model.safetensors
[INFO|tokenization_utils_base.py:2491] 2025-05-19 14:03:53,399 >> tokenizer config file saved in ./saves/Qwen2.5-0.5B/train_pt_medical_Qwen2.5-0.5B_ds2_epochs_1_datasets_old10b_wgsm8k_try_separate/checkpoint-170/tokenizer_config.json
[INFO|tokenization_utils_base.py:2500] 2025-05-19 14:03:53,402 >> Special tokens file saved in ./saves/Qwen2.5-0.5B/train_pt_medical_Qwen2.5-0.5B_ds2_epochs_1_datasets_old10b_wgsm8k_try_separate/checkpoint-170/special_tokens_map.json
[2025-05-19 14:03:53,625] [INFO] [logging.py:128:log_dist] [Rank 0] [Torch] Checkpoint global_step170 is about to be saved!
[2025-05-19 14:03:53,635] [INFO] [logging.py:128:log_dist] [Rank 0] Saving model checkpoint: ./saves/Qwen2.5-0.5B/train_pt_medical_Qwen2.5-0.5B_ds2_epochs_1_datasets_old10b_wgsm8k_try_separate/checkpoint-170/global_step170/mp_rank_00_model_states.pt
[2025-05-19 14:03:53,635] [INFO] [torch_checkpoint_engine.py:21:save] [Torch] Saving ./saves/Qwen2.5-0.5B/train_pt_medical_Qwen2.5-0.5B_ds2_epochs_1_datasets_old10b_wgsm8k_try_separate/checkpoint-170/global_step170/mp_rank_00_model_states.pt...
[2025-05-19 14:03:55,733] [INFO] [torch_checkpoint_engine.py:23:save] [Torch] Saved ./saves/Qwen2.5-0.5B/train_pt_medical_Qwen2.5-0.5B_ds2_epochs_1_datasets_old10b_wgsm8k_try_separate/checkpoint-170/global_step170/mp_rank_00_model_states.pt.
[2025-05-19 14:03:55,738] [INFO] [torch_checkpoint_engine.py:21:save] [Torch] Saving ./saves/Qwen2.5-0.5B/train_pt_medical_Qwen2.5-0.5B_ds2_epochs_1_datasets_old10b_wgsm8k_try_separate/checkpoint-170/global_step170/bf16_zero_pp_rank_0_mp_rank_00_optim_states.pt...
[2025-05-19 14:03:57,987] [INFO] [torch_checkpoint_engine.py:23:save] [Torch] Saved ./saves/Qwen2.5-0.5B/train_pt_medical_Qwen2.5-0.5B_ds2_epochs_1_datasets_old10b_wgsm8k_try_separate/checkpoint-170/global_step170/bf16_zero_pp_rank_0_mp_rank_00_optim_states.pt.
[2025-05-19 14:03:57,994] [INFO] [engine.py:3536:_save_zero_checkpoint] zero checkpoint saved ./saves/Qwen2.5-0.5B/train_pt_medical_Qwen2.5-0.5B_ds2_epochs_1_datasets_old10b_wgsm8k_try_separate/checkpoint-170/global_step170/bf16_zero_pp_rank_0_mp_rank_00_optim_states.pt
[2025-05-19 14:03:57,994] [INFO] [torch_checkpoint_engine.py:33:commit] [Torch] Checkpoint global_step170 is ready now!
[INFO|trainer.py:2643] 2025-05-19 14:03:58,287 >> 

Training completed. Do not forget to share your model on huggingface.co/models =)


{'train_runtime': 1063.4335, 'train_samples_per_second': 41.089, 'train_steps_per_second': 0.16, 'train_loss': 1.8251639422248391, 'epoch': 1.0}
100%|██████████████████████████████████████████████████████████████████████████████████████████| 170/170 [17:37<00:00,  6.22s/it]
[INFO|trainer.py:3910] 2025-05-19 14:03:58,782 >> Saving model checkpoint to ./saves/Qwen2.5-0.5B/train_pt_medical_Qwen2.5-0.5B_ds2_epochs_1_datasets_old10b_wgsm8k_try_separate
[INFO|configuration_utils.py:420] 2025-05-19 14:03:58,789 >> Configuration saved in ./saves/Qwen2.5-0.5B/train_pt_medical_Qwen2.5-0.5B_ds2_epochs_1_datasets_old10b_wgsm8k_try_separate/config.json
[INFO|configuration_utils.py:909] 2025-05-19 14:03:58,793 >> Configuration saved in ./saves/Qwen2.5-0.5B/train_pt_medical_Qwen2.5-0.5B_ds2_epochs_1_datasets_old10b_wgsm8k_try_separate/generation_config.json
[INFO|modeling_utils.py:2988] 2025-05-19 14:04:02,072 >> Model weights saved in ./saves/Qwen2.5-0.5B/train_pt_medical_Qwen2.5-0.5B_ds2_epochs_1_datasets_old10b_wgsm8k_try_separate/model.safetensors
[INFO|tokenization_utils_base.py:2491] 2025-05-19 14:04:02,108 >> tokenizer config file saved in ./saves/Qwen2.5-0.5B/train_pt_medical_Qwen2.5-0.5B_ds2_epochs_1_datasets_old10b_wgsm8k_try_separate/tokenizer_config.json
[INFO|tokenization_utils_base.py:2500] 2025-05-19 14:04:02,112 >> Special tokens file saved in ./saves/Qwen2.5-0.5B/train_pt_medical_Qwen2.5-0.5B_ds2_epochs_1_datasets_old10b_wgsm8k_try_separate/special_tokens_map.json
***** train metrics *****
  epoch                    =      0.9956
  total_flos               = 178250032GF
  train_loss               =      1.8252
  train_runtime            =  0:17:43.43
  train_samples_per_second =      41.089
  train_steps_per_second   =        0.16
Figure saved at: ./saves/Qwen2.5-0.5B/train_pt_medical_Qwen2.5-0.5B_ds2_epochs_1_datasets_old10b_wgsm8k_try_separate/training_loss.png
Figure saved at: ./saves/Qwen2.5-0.5B/train_pt_medical_Qwen2.5-0.5B_ds2_epochs_1_datasets_old10b_wgsm8k_try_separate/training_eval_test_bioasq_loss.png
Figure saved at: ./saves/Qwen2.5-0.5B/train_pt_medical_Qwen2.5-0.5B_ds2_epochs_1_datasets_old10b_wgsm8k_try_separate/training_eval_test_gsm8k_loss.png
[INFO|trainer.py:4226] 2025-05-19 14:04:02,687 >> 
***** Running Evaluation *****
[INFO|trainer.py:4228] 2025-05-19 14:04:02,688 >>   Num examples = 4829
[INFO|trainer.py:4231] 2025-05-19 14:04:02,688 >>   Batch size = 8
100%|████████████████████████████████████████████████████████████████████████████████████████████| 76/76 [00:18<00:00,  4.14it/s]
[INFO|trainer.py:4226] 2025-05-19 14:04:21,112 >> 
***** Running Evaluation *****
[INFO|trainer.py:4228] 2025-05-19 14:04:21,112 >>   Num examples = 1888
[INFO|trainer.py:4231] 2025-05-19 14:04:21,112 >>   Batch size = 8
100%|████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [00:07<00:00,  4.15it/s]
***** eval metrics *****
  epoch                               =     0.9956
  eval_test_bioasq_loss               =     2.2163
  eval_test_bioasq_perplexity         =     9.1731
  eval_test_bioasq_runtime            = 0:00:18.42
  eval_test_bioasq_samples_per_second =    262.155
  eval_test_bioasq_steps_per_second   =      4.126
  eval_test_gsm8k_loss                =     1.1564
  eval_test_gsm8k_perplexity          =     3.1786
  eval_test_gsm8k_runtime             = 0:00:07.28
  eval_test_gsm8k_samples_per_second  =    259.152
  eval_test_gsm8k_steps_per_second    =      4.118
[INFO|modelcard.py:449] 2025-05-19 14:04:28,407 >> Dropping the following result as it does not have all the necessary fields:
{'task': {'name': 'Causal Language Modeling', 'type': 'text-generation'}}
wandb: 
wandb: 🚀 View run ./saves/Qwen2.5-0.5B/train_pt_medical_Qwen2.5-0.5B_ds2_epochs_1_datasets_old10b_wgsm8k_try_separate at: https://wandb.ai/sunnyhaze/llamafactory/runs/rjd8obnd
wandb: Find logs at: wandb/run-20250519_134616-rjd8obnd/logs
```
