### PR TITLE
[data] Reading files from cloud is broken (#8182)

### DIFF
--- a/src/llamafactory/data/data_utils.py
+++ b/src/llamafactory/data/data_utils.py
@@ -152,6 +152,8 @@ def setup_fs(path, anon=False):
         fs = fsspec.filesystem("gcs", **storage_options)
     else:
         raise ValueError(f"Unsupported protocol in path: {path}. Use 's3://' or 'gs://'")
+    if not fs.exists(path):
+        raise ValueError(f"Path does not exist: {path}")
     return fs
 
 


### PR DESCRIPTION
# What does this PR do?

Fixes #8182

To ensure the ```fs.isdir(cloud_path)``` is working with a valid fs, the fs from ```setup_fs(...)``` should be initialized properly before returning.
 
## Before submitting

- [ ] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?
