### PR TITLE
Fix incorrect user_tag in dataset_info.json to prevent skipped entries

### DIFF
--- a/data/dataset_info.json
+++ b/data/dataset_info.json
@@ -274,7 +274,7 @@
     "tags": {
       "role_tag": "role",
       "content_tag": "content",
-      "user_tag": "human",
+      "user_tag": "user",
       "assistant_tag": "assistant"
     }
   },


### PR DESCRIPTION
# What does this PR do?

In the `lmsys/lmsys-chat-1m` dataset, the `user_tag` is defined as `user`. Naming it to `human` will cause `llamafactory.data.converter` to treat those entries as invalid and skip them.


## Before submitting

- [ ] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?
