### PR TITLE
feat: add smollm2 support

### DIFF
--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -1694,6 +1694,22 @@ register_template(
 
 
 register_template(
+    name="smollm2",
+    format_system=StringFormatter(
+        slots=["<|im_start|>system\n{{content}}<|im_end|>\n"]
+    ),
+    format_user=StringFormatter(
+        slots=["<|im_start|>user\n{{content}}<|im_end|>\n<|im_start|>assistant\n"]
+    ),
+    format_assistant=StringFormatter(
+        slots=["{{content}}<|im_end|>\n"]
+    ),
+    stop_words=["<|im_end|>"],
+    default_system="You are a helpful AI assistant named SmolLM, trained by Hugging Face.",
+)
+
+
+register_template(
     name="solar",
     format_user=StringFormatter(slots=["### User:\n{{content}}\n\n### Assistant:\n"]),
     format_system=StringFormatter(slots=["### System:\n{{content}}\n\n"]),

--- a/src/llamafactory/extras/constants.py
+++ b/src/llamafactory/extras/constants.py
@@ -2765,6 +2765,13 @@ register_model_group(
             DownloadSource.DEFAULT: "HuggingFaceTB/SmolLM-1.7B-Instruct",
             DownloadSource.MODELSCOPE: "HuggingFaceTB/SmolLM-1.7B-Instruct",
         },
+    },
+    template="smollm",
+)
+
+
+register_model_group(
+    models={
         "SmolLM2-135M": {
             DownloadSource.DEFAULT: "HuggingFaceTB/SmolLM2-135M",
             DownloadSource.MODELSCOPE: "HuggingFaceTB/SmolLM2-135M",
@@ -2790,7 +2797,7 @@ register_model_group(
             DownloadSource.MODELSCOPE: "HuggingFaceTB/SmolLM2-1.7B-Instruct",
         },
     },
-    template="smollm",
+    template="smollm2",
 )
 
 


### PR DESCRIPTION
# What does this PR do?

This PR adds support for the SmolLM2 model series by registering a new template ("smollm2") and model group, incorporating six model variants: SmolLM2-135M, SmolLM2-135M-Instruct, SmolLM2-360M, SmolLM2-360M-Instruct, SmolLM2-1.7B and SmolLM2-1.7B-Instruct.

### Note:
Templates for Smollm and Smolm2 are different
