### PR TITLE
feat(model): 为unsloth模型加载函数添加finetuning_args参数

### DIFF
--- a/src/llamafactory/model/adapter.py
+++ b/src/llamafactory/model/adapter.py
@@ -188,7 +188,12 @@ def _setup_lora_tuning(
 
         if adapter_to_resume is not None:  # resume lora training
             if model_args.use_unsloth:
-                model = load_unsloth_peft_model(config, model_args, is_trainable=is_trainable)
+                    model = load_unsloth_peft_model(
+                        config, 
+                        model_args, 
+                        finetuning_args,  # Add this parameter
+                        is_trainable=is_trainable
+                    )
             else:
                 model = PeftModel.from_pretrained(model, adapter_to_resume, is_trainable=is_trainable, **init_kwargs)
 
@@ -234,7 +239,12 @@ def _setup_lora_tuning(
         }
 
         if model_args.use_unsloth:
-            model = get_unsloth_peft_model(model, model_args, peft_kwargs)
+            model = load_unsloth_peft_model(
+                config, 
+                model_args, 
+                finetuning_args,  # Add this parameter
+                is_trainable=is_trainable
+            )
         else:
             if finetuning_args.pissa_init:
                 if finetuning_args.pissa_iter == -1:

--- a/src/llamafactory/model/model_utils/unsloth.py
+++ b/src/llamafactory/model/model_utils/unsloth.py
@@ -80,12 +80,20 @@ def get_unsloth_peft_model(
 
 
 def load_unsloth_peft_model(
-    config: "PretrainedConfig", model_args: "ModelArguments", is_trainable: bool
+    config: "PretrainedConfig", 
+    model_args: "ModelArguments", 
+    finetuning_args: "FinetuningArguments",  # Add this parameter
+    is_trainable: bool
 ) -> "PreTrainedModel":
     r"""Load peft model with unsloth. Used in both training and inference."""
     from unsloth import FastLanguageModel  # type: ignore
 
-    unsloth_kwargs = _get_unsloth_kwargs(config, model_args.adapter_name_or_path[0], model_args)
+    unsloth_kwargs = _get_unsloth_kwargs(
+        config, 
+        model_args.adapter_name_or_path[0], 
+        model_args,
+        finetuning_args  # Pass the argument here
+    )
     try:
         if not is_trainable:
             unsloth_kwargs["use_gradient_checkpointing"] = False


### PR DESCRIPTION
在load_unsloth_peft_model函数中新增finetuning_args参数，以便在模型加载时能够使用微调相关的配置参数。同时在调用该函数的地方相应更新参数传递。

erpair resume lora train error
TypeError: _get_unsloth_kwargs() missing 1 required positional argument: 'finetuning_args' 
