### PR TITLE
[parser] update config loading to use OmegaConf #7793

### DIFF
--- a/src/llamafactory/hparams/parser.py
+++ b/src/llamafactory/hparams/parser.py
@@ -62,11 +62,11 @@ def read_args(args: Optional[Union[dict[str, Any], list[str]]] = None) -> Union[
 
     if sys.argv[1].endswith(".yaml") or sys.argv[1].endswith(".yml"):
         override_config = OmegaConf.from_cli(sys.argv[2:])
-        dict_config = yaml.safe_load(Path(sys.argv[1]).absolute().read_text())
+        dict_config = OmegaConf.load(Path(sys.argv[1]).absolute())
         return OmegaConf.to_container(OmegaConf.merge(dict_config, override_config))
     elif sys.argv[1].endswith(".json"):
         override_config = OmegaConf.from_cli(sys.argv[2:])
-        dict_config = json.loads(Path(sys.argv[1]).absolute().read_text())
+        dict_config = OmegaConf.load(Path(sys.argv[1]).absolute())
         return OmegaConf.to_container(OmegaConf.merge(dict_config, override_config))
     else:
         return sys.argv[1:]


### PR DESCRIPTION
# What does this PR do?

Fixes #7793

Enabled automatic type casting (e.g., 5e-5 → float) using OmegaConf
- As-Is: learning_rate:5e-5 → str
- To-Be: learning_rate:5e-5 → float

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?

---
<img width="716" alt="image" src="https://github.com/user-attachments/assets/2fb9d1d8-00b5-41f4-a7f5-6676379176fc" />

- As-Is: 
```
llamafactory-cli train examples/train_lora/llama3_lora_sft.yaml
```
```
[INFO|trainer.py:756] 2025-07-01 08:26:50,461 >> Using auto half precision backend
Traceback (most recent call last):
  File "/home/name/anaconda3/bin/llamafactory-cli", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/name/LLaMA-Factory/src/llamafactory/cli.py", line 151, in main
    COMMAND_MAP[command]()
  File "/home/name/LLaMA-Factory/src/llamafactory/train/tuner.py", line 110, in run_exp
    _training_function(config={"args": args, "callbacks": callbacks})
  File "/home/name/LLaMA-Factory/src/llamafactory/train/tuner.py", line 72, in _training_function
    run_sft(model_args, data_args, training_args, finetuning_args, generating_args, callbacks)
  File "/home/name/LLaMA-Factory/src/llamafactory/train/sft/workflow.py", line 96, in run_sft
    train_result = trainer.train(resume_from_checkpoint=training_args.resume_from_checkpoint)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/name/anaconda3/lib/python3.12/site-packages/transformers/trainer.py", line 2240, in train
    return inner_training_loop(
           ^^^^^^^^^^^^^^^^^^^^
  File "/home/name/anaconda3/lib/python3.12/site-packages/transformers/trainer.py", line 2325, in _inner_training_loop
    self.create_optimizer_and_scheduler(num_training_steps=max_steps)
  File "/home/name/anaconda3/lib/python3.12/site-packages/transformers/trainer.py", line 1181, in create_optimizer_and_scheduler
    self.create_optimizer()
  File "/home/name/LLaMA-Factory/src/llamafactory/train/sft/trainer.py", line 85, in create_optimizer
    return super().create_optimizer()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/name/anaconda3/lib/python3.12/site-packages/transformers/trainer.py", line 1246, in create_optimizer
    self.optimizer = optimizer_cls(optimizer_grouped_parameters, **optimizer_kwargs)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/name/anaconda3/lib/python3.12/site-packages/torch/optim/adamw.py", line 37, in __init__
    super().__init__(
  File "/home/name/anaconda3/lib/python3.12/site-packages/torch/optim/adam.py", line 57, in __init__
    if not 0.0 <= lr:
           ^^^^^^^^^
TypeError: '<=' not supported between instances of 'float' and 'str'
```
- To-Be: No TypeError about learning_rate like 5e-5