### PR TITLE
Revert "[model] add lora dropout to unsloth (#8548)" - requested feature already exists

### DIFF
--- a/src/llamafactory/model/model_utils/unsloth.py
+++ b/src/llamafactory/model/model_utils/unsloth.py
@@ -40,7 +40,6 @@ def _get_unsloth_kwargs(
         "load_in_4bit": model_args.quantization_bit == 4,
         "token": model_args.hf_hub_token,
         "full_finetuning": finetuning_args.finetuning_type == "full",
-        "lora_dropout": finetuning_args.lora_dropout,
         "device_map": {"": get_current_device()},
         "rope_scaling": getattr(config, "rope_scaling", None),
         "fix_tokenizer": False,


### PR DESCRIPTION

# What does this PR do?

This PR reverts #8548. 

The requested feature in #8518 already [exists](https://github.com/hiyouga/LLaMA-Factory/blob/main/src/llamafactory/model/adapter.py#L230) and is correctly passed to `FastLanguageModel.get_peft_model`, instead of `FastLanguageModel.from_pretrained`.

Apologies for not noticing this earlier and for all the confusion -- I was searching for this arg in the wrong place. I hope we're able to merge this quickly so others do not face issues!

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
