### PR TITLE
docs: Add comprehensive LoRA target parameter documentation

### DIFF
--- a/docs/lora_target.md
+++ b/docs/lora_target.md
@@ -1,0 +1,66 @@
+## LoRA Target Parameter
+
+### What is lora_target?
+
+The `lora_target` parameter controls which layers in your model get LoRA adapters during fine-tuning. You can apply LoRA to all compatible layers or target specific modules.
+
+### Basic Usage
+
+```yaml
+# Apply to all linear modules (recommended default)
+lora_target: all
+
+# Target specific modules
+lora_target: q_proj,v_proj
+```
+
+### Common Module Names
+
+Different models use different naming conventions:
+
+**LLaMA/Mistral/Alpaca:**
+- Attention: `q_proj`, `k_proj`, `v_proj`, `o_proj`
+- MLP: `gate_proj`, `up_proj`, `down_proj`
+
+**ChatGLM:**
+- Attention: `query_key_value`
+- MLP: `dense`, `dense_h_to_4h`, `dense_4h_to_h`
+
+**Qwen:**
+- Attention: `c_attn`, `c_proj`
+- MLP: `w1`, `w2`
+
+### Finding Module Names
+
+The easiest way is to set `lora_target: all` and check the training logs for "Found linear modules:" - this shows all available modules for your model.
+
+### Examples
+
+**Memory-constrained training:**
+```yaml
+# Target only attention layers
+lora_target: q_proj,k_proj,v_proj,o_proj
+lora_rank: 8
+```
+
+**Task-specific fine-tuning:**
+```yaml
+# Mix attention and MLP modules
+lora_target: q_proj,v_proj,gate_proj,down_proj
+lora_rank: 16
+```
+
+### Tips
+
+- Start with `all` unless you have memory constraints
+- For classification tasks, attention modules often suffice
+- For knowledge-intensive tasks, include MLP modules
+- Wrong module names will cause errors - double-check against your model
+
+### Troubleshooting
+
+**"Module not found" error:** Check module names match your model architecture. Use `lora_target: all` first to see available options.
+
+**High memory usage:** Target fewer modules or just attention layers.
+
+**Poor results:** Try using `all` or including both attention and MLP modules.


### PR DESCRIPTION
Fixes #7627

## Description

This PR adds comprehensive documentation for the `lora_target` parameter, which was requested in Issue #7627. Many users have been confused about how to effectively use this parameter, and this documentation aims to clarify its usage.

## What's included

- **Clear explanation**: What `lora_target` does and why it matters
- **Basic usage examples**: Shows both `all` and specific module targeting
- **Module names reference**: Common module names for popular models (LLaMA, Mistral, ChatGLM, Qwen, etc.)
- **Discovery method**: How to find available modules for any model
- **Practical examples**: Real-world scenarios like memory-constrained training
- **Troubleshooting guide**: Common issues and solutions

## Why this is useful

The `lora_target` parameter is crucial for:
- Managing memory usage during training
- Optimizing fine-tuning for specific tasks
- Understanding which parts of the model to adapt

This documentation makes it easier for users to:
- Choose the right modules for their use case
- Debug common errors
- Optimize their training configuration

## Testing

The examples and module names have been verified against the actual model implementations and common usage patterns in the community.