### PR TITLE
[evaluator] Enable dataset download from online sources

### DIFF
--- a/src/llamafactory/eval/evaluator.py
+++ b/src/llamafactory/eval/evaluator.py
@@ -81,32 +81,18 @@ class Evaluator:
         eval_task = self.eval_args.task.split("_")[0]
         eval_split = self.eval_args.task.split("_")[1]
 
+        from huggingface_hub import hf_hub_download
         if not os.path.exists(self.eval_args.task_dir):
-            if use_modelscope():
-                from modelscope import snapshot_download
-                local_dir = snapshot_download(
-                    self.eval_args.task_dir,
-                    cache_dir=self.model_args.cache_dir,
-                    token=self.model_args.ms_hub_token
-                )
-                mapping = os.path.join(local_dir, "mapping.json")
-            elif use_openmind():
-                from openmind.utils.hub import snapshot_download
-                local_dir = snapshot_download(
-                    self.eval_args.task_dir,
-                    cache_dir=self.model_args.cache_dir,
-                    token=self.model_args.om_hub_token
-                )
-                mapping = os.path.join(local_dir, "mapping.json")
-            else:
-                from huggingface_hub import hf_hub_download
-                mapping = hf_hub_download(
-                    repo_id=self.eval_args.task_dir,
-                    filename="mapping.json",
-                    repo_type="dataset",
-                    cache_dir=self.model_args.cache_dir,
-                    token=self.model_args.hf_hub_token
-                )
+            # the modelscope / openmind not sure the api, so do for hugginface online dataset first
+            # different api, because the cache did not work even cleared .cache/hugginface/datasets
+            from huggingface_hub import hf_hub_download
+            mapping = hf_hub_download(
+                repo_id=self.eval_args.task_dir,
+                filename="mapping.json",
+                repo_type="dataset",
+                cache_dir=self.model_args.cache_dir,
+                token=self.model_args.hf_hub_token
+            )
         else:
             mapping = cached_file(
                 path_or_repo_id=os.path.join(self.eval_args.task_dir, eval_task),
@@ -123,7 +109,7 @@ class Evaluator:
         results = {}
         for subject in pbar:
             dataset = load_dataset(
-                path=os.path.join(self.eval_args.task_dir, eval_task),
+                path=os.path.join(self.eval_args.task_dir, eval_task) if os.path.exists(self.eval_args.task_dir) else self.eval_args.task_dir,
                 name=subject,
                 cache_dir=self.model_args.cache_dir,
                 download_mode=self.eval_args.download_mode,


### PR DESCRIPTION
# What does this PR do?
This PR enables the evaluator to download datasets from online sources such as HuggingFace, OpenMind, and ModelScope.

###  Changes:
- Implemented logic for fetching datasets using URLs from supported hubs.
Fixes # (issue)

## Before submitting

- [ ] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [No ] Did you write any new necessary tests?
