### PR TITLE
fix(embedding): adjust logits size after adding special tokens

### DIFF
--- a/src/llamafactory/model/model_utils/embedding.py
+++ b/src/llamafactory/model/model_utils/embedding.py
@@ -67,4 +67,5 @@ def resize_embedding_layer(model: "PreTrainedModel", tokenizer: "PreTrainedToken
             _noisy_mean_initialization(model.get_input_embeddings().weight.data, num_new_tokens)
             _noisy_mean_initialization(model.get_output_embeddings().weight.data, num_new_tokens)
 
+        model.config.vocab_size = new_embedding_size
         logger.info_rank0(f"Resized token embeddings from {current_embedding_size} to {new_embedding_size}.")


### PR DESCRIPTION
# What does this PR do?

### Background
During fine-tuning of **Qwen-2.5-VL**, several new special tokens are appended to the tokenizer.

### Issue
After `model.resize_token_embeddings()`, `self.config.vocab_size` still keeps the original value **151 936**.  When computing `loss = criterion(logits, labels, vocab_size=self.config.vocab_size)` the last dimension of logits mismatches vocab_size and triggers a shape error.

### Validation

Reproduced the shape-mismatch error on 1×A800; training proceeds normally after the fix.


### Error Log
```
[rank3]: Traceback (most recent call last):
[rank3]:   File "LLaMA-Factory/src/llamafactory/launcher.py", line 23, in <module>
[rank3]:     launch()
[rank3]:   File "LLaMA-Factory/src/llamafactory/launcher.py", line 19, in launch
[rank3]:     run_exp()
[rank3]:   File "LLaMA-Factory/src/llamafactory/train/tuner.py", line 110, in run_exp
[rank3]:     _training_function(config={"args": args, "callbacks": callbacks})
[rank3]:   File "LLaMA-Factory/src/llamafactory/train/tuner.py", line 72, in _training_function
[rank3]:     run_sft(model_args, data_args, training_args, finetuning_args, generating_args, callbacks)
[rank3]:   File "LLaMA-Factory/src/llamafactory/train/sft/workflow.py", line 96, in run_sft
[rank3]:     train_result = trainer.train(resume_from_checkpoint=training_args.resume_from_checkpoint)
[rank3]:   File "/home/anaconda3/envs/llama-factory/lib/python3.10/site-packages/transformers/trainer.py", line 2240, in train
[rank3]:     return inner_training_loop(
[rank3]:   File "/home/anaconda3/envs/llama-factory/lib/python3.10/site-packages/transformers/trainer.py", line 2555, in _inner_training_loop
[rank3]:     tr_loss_step = self.training_step(model, inputs, num_items_in_batch)
[rank3]:   File "/home/anaconda3/envs/llama-factory/lib/python3.10/site-packages/transformers/trainer.py", line 3745, in training_step
[rank3]:     loss = self.compute_loss(model, inputs, num_items_in_batch=num_items_in_batch)
[rank3]:   File "LLaMA-Factory/src/llamafactory/train/sft/trainer.py", line 103, in compute_loss
[rank3]:     return super().compute_loss(model, inputs, *args, **kwargs)
[rank3]:   File "/home/anaconda3/envs/llama-factory/lib/python3.10/site-packages/transformers/trainer.py", line 3810, in compute_loss
[rank3]:     outputs = model(**inputs)
[rank3]:   File "/home/anaconda3/envs/llama-factory/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1736, in _wrapped_call_impl
[rank3]:     return self._call_impl(*args, **kwargs)
[rank3]:   File "/home/anaconda3/envs/llama-factory/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1747, in _call_impl
[rank3]:     return forward_call(*args, **kwargs)
[rank3]:   File "/home/anaconda3/envs/llama-factory/lib/python3.10/site-packages/deepspeed/utils/nvtx.py", line 18, in wrapped_fn
[rank3]:     ret_val = func(*args, **kwargs)
[rank3]:   File "/home/anaconda3/envs/llama-factory/lib/python3.10/site-packages/deepspeed/runtime/engine.py", line 1909, in forward
[rank3]:     loss = self.module(*inputs, **kwargs)
[rank3]:   File "/home/anaconda3/envs/llama-factory/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1736, in _wrapped_call_impl
[rank3]:     return self._call_impl(*args, **kwargs)
[rank3]:   File "/home/anaconda3/envs/llama-factory/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1747, in _call_impl
[rank3]:     return forward_call(*args, **kwargs)
[rank3]:   File "/home/anaconda3/envs/llama-factory/lib/python3.10/site-packages/transformers/utils/generic.py", line 969, in wrapper
[rank3]:     output = func(self, *args, **kwargs)
[rank3]:   File "/home/anaconda3/envs/llama-factory/lib/python3.10/site-packages/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py", line 1931, in forward
[rank3]:     loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.vocab_size)
[rank3]:   File "/home/anaconda3/envs/llama-factory/lib/python3.10/site-packages/transformers/loss/loss_utils.py", line 60, in ForCausalLMLoss
[rank3]:     logits = logits.view(-1, vocab_size)
[rank3]: RuntimeError: shape '[-1, 151936]' is invalid for input of size 967532544
```

Fixes # (issue)

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
