### PR TITLE
Fix(loader): Resolve file lock issue when deleting safetensors on Windows

### DIFF
--- a/src/llamafactory/train/callbacks.py
+++ b/src/llamafactory/train/callbacks.py
@@ -73,7 +73,7 @@ def fix_valuehead_checkpoint(
     if safe_serialization:
         path_to_checkpoint = os.path.join(output_dir, SAFE_WEIGHTS_NAME)
         with safe_open(path_to_checkpoint, framework="pt", device="cpu") as f:
-            state_dict: dict[str, torch.Tensor] = {key: f.get_tensor(key) for key in f.keys()}
+            state_dict: dict[str, torch.Tensor] = {key: f.get_tensor(key).clone() for key in f.keys()}
     else:
         path_to_checkpoint = os.path.join(output_dir, WEIGHTS_NAME)
         state_dict: dict[str, torch.Tensor] = torch.load(path_to_checkpoint, map_location="cpu", weights_only=True)


### PR DESCRIPTION
# What does this PR do?

## Description
This pull request resolves the file locking issue on Windows by ensuring the file handle is released immediately after its contents are loaded into memory. 

## Motivation
On the Windows operating system, after loading a model using safetensors.torch.safe_open, any attempt to immediately delete the file with os.remove() fails with a PermissionError.

This is caused by safe_open's use of memory-mapping. The loaded Tensors hold a direct reference to the mapped file handle, and as long as these Tensors remain in memory, the Windows OS maintains a lock on the file, preventing its deletion. This PR aims to resolve this platform-specific issue to ensure consistent behavior across different operating systems.

## Minimal Reproducible Code
```python
import os
from safetensors import safe_open
import torch
path_to_checkpoint="model.safetensors"
with safe_open(path_to_checkpoint, framework="pt", device="cpu") as f:
    state_dict: dict[str, torch.Tensor] = {key: f.get_tensor(key) for key in f.keys()}
    pass
os.remove(path_to_checkpoint)
```
## Solve
To fix the "permission denied" error on Windows, just .clone() the tensors as you load them to release the file lock.
