### PR TITLE
[export] Add export_hub_private option for pushing to private Hugging Face repos

### DIFF
--- a/src/llamafactory/hparams/model_args.py
+++ b/src/llamafactory/hparams/model_args.py
@@ -172,6 +172,11 @@ class BaseModelArguments:
         metadata={"help": "Whether to trust the execution of code from datasets/models defined on the Hub or not."},
     )
 
+    export_hub_private: bool = field(
+        default=False,
+        metadata={"help": "Whether to push the model and tokenizer to a private repository on the Hugging Face hub."},
+    )
+
     def __post_init__(self):
         if self.model_name_or_path is None:
             raise ValueError("Please provide `model_name_or_path`.")

--- a/src/llamafactory/train/tuner.py
+++ b/src/llamafactory/train/tuner.py
@@ -156,6 +156,7 @@ def export_model(args: Optional[dict[str, Any]] = None) -> None:
             token=model_args.hf_hub_token,
             max_shard_size=f"{model_args.export_size}GB",
             safe_serialization=(not model_args.export_legacy_format),
+            private=model_args.export_hub_private
         )
 
     if finetuning_args.stage == "rm":
@@ -182,12 +183,12 @@ def export_model(args: Optional[dict[str, Any]] = None) -> None:
         tokenizer.init_kwargs["padding_side"] = "left"
         tokenizer.save_pretrained(model_args.export_dir)
         if model_args.export_hub_model_id is not None:
-            tokenizer.push_to_hub(model_args.export_hub_model_id, token=model_args.hf_hub_token)
+            tokenizer.push_to_hub(model_args.export_hub_model_id, token=model_args.hf_hub_token, private=model_args.export_hub_private)
 
         if processor is not None:
             processor.save_pretrained(model_args.export_dir)
             if model_args.export_hub_model_id is not None:
-                processor.push_to_hub(model_args.export_hub_model_id, token=model_args.hf_hub_token)
+                processor.push_to_hub(model_args.export_hub_model_id, token=model_args.hf_hub_token, private=model_args.export_hub_private)
 
     except Exception as e:
         logger.warning_rank0(f"Cannot save tokenizer, please copy the files manually: {e}.")


### PR DESCRIPTION

# What does this PR do?
This PR adds support for exporting to private Hugging Face repositories by introducing a new argument.

✅ Changes

1. Added export_hub_private: bool = False to BaseModelArguments.
2. Modified the following in src/llamafactory/train/tuner.py to respect the private flag:
&nbsp;&nbsp;- model.push_to_hub(..., private=export_hub_private)
&nbsp;&nbsp;- tokenizer.push_to_hub(..., private=export_hub_private)
&nbsp;&nbsp;- processor.push_to_hub(..., private=export_hub_private)

Fixes # (issue)

## Before submitting

- [ ] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ No] Did you write any new necessary tests?
