### PR TITLE
[data-loader] Allow `dataset_dir` to accept a dict for in-memory dataset_info

### DIFF
--- a/src/llamafactory/data/parser.py
+++ b/src/llamafactory/data/parser.py
@@ -15,7 +15,7 @@
 import json
 import os
 from dataclasses import dataclass
-from typing import Any, Literal, Optional
+from typing import Any, Literal, Optional, Union
 
 from huggingface_hub import hf_hub_download
 
@@ -90,12 +90,14 @@ class DatasetAttr:
                 self.set_attr(tag, attr["tags"])
 
 
-def get_dataset_list(dataset_names: Optional[list[str]], dataset_dir: str) -> list["DatasetAttr"]:
+def get_dataset_list(dataset_names: Optional[list[str]], dataset_dir: Union[str, dict]) -> list["DatasetAttr"]:
     r"""Get the attributes of the datasets."""
     if dataset_names is None:
         dataset_names = []
 
-    if dataset_dir == "ONLINE":
+    if isinstance(dataset_dir, dict):
+        dataset_info = dataset_dir
+    elif dataset_dir == "ONLINE":
         dataset_info = None
     else:
         if dataset_dir.startswith("REMOTE:"):

--- a/src/llamafactory/hparams/data_args.py
+++ b/src/llamafactory/hparams/data_args.py
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 from dataclasses import asdict, dataclass, field
-from typing import Any, Literal, Optional
+from typing import Any, Literal, Optional, Union
 
 
 @dataclass
@@ -35,7 +35,7 @@ class DataArguments:
         default=None,
         metadata={"help": "The name of dataset(s) to use for evaluation. Use commas to separate multiple datasets."},
     )
-    dataset_dir: str = field(
+    dataset_dir: Union[str, dict] = field(
         default="data",
         metadata={"help": "Path to the folder containing the datasets."},
     )


### PR DESCRIPTION
### Summary

Currently, `dataset_dir` must be either a string pointing to a local folder, an `ONLINE` keyword (for Hugging Face Hub), or a remote path starting with `REMOTE:`.

However, in some use cases — such as dynamic programmatic configuration or avoiding file I/O — it is desirable to pass a pre-parsed `dict` (i.e., already-loaded dataset_info) directly.

This PR enables that by allowing `dataset_dir` to be a `dict` as well.

# What does this PR do?
- Check if `dataset_dir` is a `dict`, and if so, use it directly as `dataset_info`.
- Keeps backward compatibility for string-based usage (`ONLINE`, local path, and `REMOTE:` cases).


### Motivation

This improves flexibility and allows advanced users (e.g., internal toolchains or auto-generated dataset configs) to use `dataset_dir` as a native dict, without needing intermediate JSON files or Hugging Face downloads.

### Notes

- I intentionally limited the change to the core data loading logic.
- If the maintainers find this direction useful, I’d be happy to help adapt the Web UI or other interfaces in follow-up PRs.
- 
## Before submitting

- [ ] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [] Did you write any new necessary tests?
