### PR TITLE
add data preprocessing controls

### DIFF
--- a/src/llamafactory/hparams/data_args.py
+++ b/src/llamafactory/hparams/data_args.py
@@ -137,6 +137,27 @@ class DataArguments:
         default=False,
         metadata={"help": "Whether or not to use a shared file system for the datasets."},
     )
+    force_sequence_length_padding: bool = field(
+        default=False,
+        metadata={
+            "help": (
+                "Force all sequences to be padded to cutoff_len during preprocessing. "
+                "Required for sequence parallelism compatibility. When enabled, all samples "
+                "will be exactly cutoff_len tokens, padding with pad tokens as needed."
+            )
+        },
+    )
+    force_max_length_padding: bool = field(
+        default=False,
+        metadata={
+            "help": (
+                "Force all sequences to be padded to the maximum length found in the dataset "
+                "during preprocessing. This ensures all samples have identical lengths based on "
+                "the longest sample, improving training efficiency. Cannot be used with "
+                "force_sequence_length_padding."
+            )
+        },
+    )
 
     def __post_init__(self):
         def split_arg(arg):

--- a/src/llamafactory/hparams/model_args.py
+++ b/src/llamafactory/hparams/model_args.py
@@ -87,6 +87,13 @@ class BaseModelArguments:
         default=None,
         metadata={"help": "Which scaling strategy should be adopted for the RoPE embeddings."},
     )
+    model_capacity: Optional[int] = field(
+        default=None,
+        metadata={
+            "help": "Override model max_position_embeddings independent of cutoff_len. "
+            "If specified, this determines the model's maximum context length instead of using cutoff_len."
+        },
+    )
     flash_attn: AttentionFunction = field(
         default=AttentionFunction.AUTO,
         metadata={"help": "Enable FlashAttention for faster training and inference."},


### PR DESCRIPTION
# What does this PR do?

Adds the ability to pad datasets to either the maximum cutoff length or the maximum sample length. This is useful for certain types of training such as sequence parallel training or stress testing long-context samples.

Fixes # (issue)

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
