### PR TITLE
[model] add ernie4_5_moe support for DeepSpeed Zero3 training

### DIFF
--- a/src/llamafactory/model/model_utils/moe.py
+++ b/src/llamafactory/model/model_utils/moe.py
@@ -55,6 +55,11 @@ def add_z3_leaf_module(model: "PreTrainedModel") -> None:
         # deepseek v3 and kimi vl use custom code
         _set_z3_leaf_modules(model, ["DeepseekV3MoE"])
 
+    if model_type == "ernie4_5_moe":
+        from transformers.models.ernie4_5_moe.modeling_ernie4_5_moe import Ernie4_5_MoeSparseMoeBlock
+
+        _set_z3_leaf_modules(model, [Ernie4_5_MoeSparseMoeBlock])
+
     if model_type == "granitemoe":
         from transformers.models.granitemoe.modeling_granitemoe import GraniteMoeMoE
 
@@ -130,6 +135,7 @@ def configure_moe(config: "PretrainedConfig", model_args: "ModelArguments", is_t
 
     if model_type in [
         "dbrx",
+        "ernie4_5_moe",
         "granitemoe",
         "jamba",
         "jetmoe",
@@ -148,7 +154,7 @@ def configure_moe(config: "PretrainedConfig", model_args: "ModelArguments", is_t
     ]:
         setattr(text_config, "output_router_logits", True)
 
-    if model_type in ["granitemoe", "jamba", "llama4", "mixtral", "olmoe", "phimoe", "qwen2_moe", "qwen3_moe"]:
+    if model_type in ["ernie4_5_moe", "granitemoe", "jamba", "llama4", "mixtral", "olmoe", "phimoe", "qwen2_moe", "qwen3_moe"]:
         setattr(config, "router_aux_loss_coef", model_args.moe_aux_loss_coef)
 
     elif text_config and getattr(text_config, "model_type", None) in ["qwen3_moe"]:


### PR DESCRIPTION
- Add Ernie4_5_MoeSparseMoeBlock to z3_leaf_modules in add_z3_leaf_module function
- Add ernie4_5_moe to models that support output_router_logits configuration
- Add ernie4_5_moe to models that support router_aux_loss_coef configuration
- Fixes forward pass hanging issue during Zero3 training with ernie moe models

# What does this PR do?

Adds support for ernie4_5_moe models in DeepSpeed Zero3 training by configuring the appropriate leaf modules and MoE-specific settings.

## Changes Made

- Added `Ernie4_5_MoeSparseMoeBlock` to the list of leaf modules in `add_z3_leaf_module` function
- Added `ernie4_5_moe` to models that support `output_router_logits` configuration
- Added `ernie4_5_moe` to models that support `router_aux_loss_coef` configuration

## Problem Solved

Fixes the issue where ernie moe models would hang during forward pass when using DeepSpeed Zero3 training. This was caused by the MoE blocks not being properly configured as leaf modules, preventing Zero3 from partitioning them correctly.

## Testing

- [x] Code follows the project's style guidelines
- [x] Changes are backward compatible
- [x] No new tests required (configuration changes only)

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests? (Not applicable - configuration changes only)
