### PR TITLE
fix: add deepstack_merger_list to Qwen3-VL vision_model_keys

### DIFF
--- a/src/llamafactory/model/model_utils/visual.py
+++ b/src/llamafactory/model/model_utils/visual.py
@@ -355,7 +355,7 @@ _register_composite_model(
 _register_composite_model(
     model_type="qwen3_vl",
     projector_key="visual.merger",
-    vision_model_keys=["visual.patch_embed", "visual.blocks"],
+    vision_model_keys=["visual.patch_embed", "visual.blocks", "visual.deepstack_merger_list"],
     language_model_keys=["language_model", "lm_head"],
     lora_conflict_keys=["patch_embed"],
 )
@@ -364,7 +364,7 @@ _register_composite_model(
 _register_composite_model(
     model_type="qwen3_vl_moe",
     projector_key="visual.merger",
-    vision_model_keys=["visual.patch_embed", "visual.blocks"],
+    vision_model_keys=["visual.patch_embed", "visual.blocks", "visual.deepstack_merger_list"],
     language_model_keys=["language_model", "lm_head"],
     lora_conflict_keys=["patch_embed"],
 )
@@ -373,7 +373,7 @@ _register_composite_model(
 _register_composite_model(
     model_type="qwen3_omni_moe_thinker",
     projector_key="visual.merger",
-    vision_model_keys=["visual.patch_embed", "visual.blocks", "audio_tower"],
+    vision_model_keys=["visual.patch_embed", "visual.blocks", "visual.deepstack_merger_list", "audio_tower"],
     language_model_keys=["model", "lm_head"],
     lora_conflict_keys=["patch_embed"],
 )


### PR DESCRIPTION
## Description
This PR fixes an issue where Qwen3-VL's DeepStack merger modules were unintentionally trained when `freeze_vision_tower=True` (the default setting).

## Problem
- Qwen3-VL introduced DeepStack feature with `deepstack_merger_list` modules
- These modules were not included in `vision_model_keys`
- When `freeze_vision_tower=True`, only `visual.patch_embed` and `visual.blocks` were frozen
- `visual.deepstack_merger_list` remained trainable, causing:
  - Unexpected LoRA adapters in vision components
  - Inconsistent behavior with freeze_vision_tower intent

## Changes
Added `"visual.deepstack_merger_list"` to `vision_model_keys` for:
- `qwen3_vl`
- `qwen3_vl_moe`
- `qwen3_omni_moe_thinker`

**Code change:**
```python
# In src/llamafactory/model/model_utils/visual.py
vision_model_keys=["visual.patch_embed", "visual.blocks", "visual.deepstack_merger_list"]
```

## Impact
- Ensures DeepStack mergers are properly frozen when `freeze_vision_tower=True`
- Aligns behavior with other vision model architectures
- Improves consistency between intended and actual freezing behavior

## Background
Qwen3-VL's DeepStack feature uses merger modules to process multi-level visual features from the vision transformer. These modules should be treated as part of the vision tower for proper freezing behavior.