### PR TITLE
[train] fix ga scale in ksft loss

### DIFF
--- a/src/llamafactory/train/ksft/workflow.py
+++ b/src/llamafactory/train/ksft/workflow.py
@@ -83,6 +83,7 @@ def run_sft(
         **dataset_module,
         **metric_module,
     )
+    trainer.model_accepts_loss_kwargs = False
 
     # Training
     if training_args.do_train:


### PR DESCRIPTION
Set model_accepts_loss_kwargs to False before training, avoiding the absence of gradient accumulation.

# What does this PR do?

Fixes # (issue)

## Before submitting

- [ ] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?
