### PR TITLE
adds "openai" option to `formatting`. This enables selecting `OpenAIDatasetConverter`.

### DIFF
--- a/src/llamafactory/data/parser.py
+++ b/src/llamafactory/data/parser.py
@@ -30,7 +30,7 @@ class DatasetAttr:
     # basic configs
     load_from: Literal["hf_hub", "ms_hub", "om_hub", "script", "file"]
     dataset_name: str
-    formatting: Literal["alpaca", "sharegpt"] = "alpaca"
+    formatting: Literal["alpaca", "sharegpt", "openai"] = "alpaca"
     ranking: bool = False
     # extra configs
     subset: Optional[str] = None


### PR DESCRIPTION
`OpenAIDatasetConverter` is implemented in `data/converter.py`.
But you can't choose it because there's no option on `DatasetAttr.formatting`.

# What does this PR do?
adds "openai" option to `DatasetAttr.formatting`

Fixes # (issue)

## Before submitting

- [*] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?
