### PR TITLE
[chat] fix the error when the vLLM version is greater than 0.10.0

### DIFF
--- a/src/llamafactory/chat/vllm_engine.py
+++ b/src/llamafactory/chat/vllm_engine.py
@@ -31,11 +31,8 @@ from .base_engine import BaseEngine, Response
 
 
 if is_vllm_available():
-    import vllm
     from vllm import AsyncEngineArgs, AsyncLLMEngine, RequestOutput, SamplingParams
     from vllm.lora.request import LoRARequest
-else:
-    vllm = None
 
 
 if TYPE_CHECKING:
@@ -85,6 +82,8 @@ class VllmEngine(BaseEngine):
             "enable_lora": model_args.adapter_name_or_path is not None,
             "max_lora_rank": model_args.vllm_max_lora_rank,
         }
+
+        import vllm
 
         if version.parse(vllm.__version__) <= version.parse("0.10.0"):
             engine_args["disable_log_requests"] = True


### PR DESCRIPTION
# What does this PR do?

When using VLLM for backend inference, an error occurs when the VLLM version is greater than 0.10.0. This is because, starting with version 0.10.1, the `disable_log_requests` parameter was removed and replaced with `enable_log_requests`. Therefore, the VLLM version should be checked here to select the correct parameter.
