### PR TITLE
[V1] Refactor ascend MoE kernel patch logic & Support Qwen3-MoE

### DIFF
--- a/src/llamafactory/v1/extras/packages.py
+++ b/src/llamafactory/v1/extras/packages.py
@@ -1,0 +1,43 @@
+# Copyright 2025 HuggingFace Inc. and the LlamaFactory team.
+#
+# This code is inspired by the HuggingFace's transformers library.
+# https://github.com/huggingface/transformers/blob/v4.40.0/src/transformers/utils/import_utils.py
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.metadata
+import importlib.util
+from functools import lru_cache
+from typing import TYPE_CHECKING
+
+from packaging import version
+
+
+if TYPE_CHECKING:
+    from packaging.version import Version
+
+
+def _is_package_available(name: str) -> bool:
+    return importlib.util.find_spec(name) is not None
+
+
+def _get_package_version(name: str) -> "Version":
+    try:
+        return version.parse(importlib.metadata.version(name))
+    except Exception:
+        return version.parse("0.0.0")
+
+
+@lru_cache
+def is_transformers_version_greater_than(content: str):
+    return _get_package_version("transformers") >= version.parse(content)

--- a/src/llamafactory/v1/plugins/model_plugins/kernels/mlp/npu_fused_moe.py
+++ b/src/llamafactory/v1/plugins/model_plugins/kernels/mlp/npu_fused_moe.py
@@ -17,9 +17,8 @@ import types
 import torch
 import torch.nn.functional as F
 import torch_npu
-import transformers
-from packaging import version
 
+from .....extras.packages import is_transformers_version_greater_than
 from .....extras.types import HFModel
 from ....trainer_plugins.distributed.accelerate import is_torch_npu_available
 from ..constants import DeviceType, KernelType
@@ -194,8 +193,6 @@ class Qwen3NpuMoeFused:
 
 
 # moe patch config mapping
-IS_BELOW_V5 = version.parse(transformers.__version__) < version.parse("5.0.0")
-
 kernel_moe_mapping = {
     "Qwen3VLMoeForConditionalGeneration": {
         "Qwen3VLMoeTextExperts": NpuMoeFused.npu_moe_experts_forward,
@@ -203,7 +200,7 @@ kernel_moe_mapping = {
     }
 }
 
-if IS_BELOW_V5:
+if not is_transformers_version_greater_than("5.0.0"):
     kernel_moe_mapping["Qwen3MoeForCausalLM"] = {
         "Qwen3MoeSparseMoeBlock": Qwen3NpuMoeFused.qwen3moe_sparse_moe_block_forward
     }


### PR DESCRIPTION
# What does this PR do?

This PR refactors the NPU MoE fused operator implementation and adds support for Qwen3-MoE models.

## Refactored Patch Mechanism
Changed the hardcoded patch logic to a cleaner mapping configuration (kernel_moe_mapping). This makes it much easier to add support for new architectures in the future by simply updating the config dictionary. 

```
kernel_moe_mapping = {
    "Qwen3VLMoeForConditionalGeneration": 
        {
            "Qwen3VLMoeTextExperts": NpuMoeFused.npu_moe_experts_forward,
            "Qwen3VLMoeTextSparseMoeBlock": NpuMoeFused.npu_moe_sparse_block_forward,
        }
}

....

archs = getattr(model.config, "architectures", [])
        target_moe_mapping = None
        for arch in archs:
            if arch in kernel_moe_mapping:
                target_moe_mapping = kernel_moe_mapping[arch]
                break

...

return model
```

## Transformers v5.0.0 Compatibility

We have proactively prepared for transformers v5.0.0, which introduces a unified logic for MoE classes. You can check this pr to see change https://github.com/huggingface/transformers/pull/41580. In short, most moe mode will support MoeSparseMoeBlock - TopKRouter - MoeExperts class structure and combined gate_proj and up_proj during loadind weight with newly introduced class `WeightConverter`  in v5.0.0.

- So this pr extracted the current implementation (derived from Qwen3-VL-MoE) into a base function. Once LlamaFactory supports transformers v5.0.0, most fused operators can directly reuse this generalized logic.
-  For models like Qwen3-MoE, the model structure in v5.0.0 differs  and is incompatible with the current v4.57 fused operator implementation. Therefor, I added a version check to the configuration mapping to skip these patches on v5.0.0+, preventing potential conflicts in the future.

```
# moe patch config mapping
IS_BELOW_V5 = version.parse(transformers.__version__) < version.parse("5.0.0")

kernel_moe_mapping = {
    "Qwen3VLMoeForConditionalGeneration": 
        {
            "Qwen3VLMoeTextExperts": NpuMoeFused.npu_moe_experts_forward,
            "Qwen3VLMoeTextSparseMoeBlock": NpuMoeFused.npu_moe_sparse_block_forward,
        }
}

if IS_BELOW_V5:
    kernel_moe_mapping["Qwen3MoeForCausalLM"] = {
         "Qwen3MoeSparseMoeBlock": Qwen3NpuMoeFused.qwen3moe_sparse_moe_block_forward
    }

```


## Added Qwen3-MoE Support

Enabled fused operators for Qwen3-MoE Causal LM. In transformers v4.57.x, gate_proj and up_proj are not pre-merged, and merging them at runtime causes excessive VRAM overhead. Therefore, I implemented a Dual-GMM approach (calculating them separately) to minimize VRAM usage while maintaining acceleration.

Accuracy was verified on the NPU using a reduced-layer Qwen3-30B model. The results confirm that the loss curve aligns with the baseline (see the loss error comparison chart below).

<img width="720" height="804" alt="image" src="https://github.com/user-attachments/assets/208c2b7c-3a78-4225-9313-462b5df785fa" />


## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?
