### PR TITLE
Fix RoPE scaling patch for resuming from a scaled model

### DIFF
--- a/src/llamafactory/model/model_utils/rope.py
+++ b/src/llamafactory/model/model_utils/rope.py
@@ -41,8 +41,8 @@ def configure_rope(config: "PretrainedConfig", model_args: "ModelArguments") -> 
         return
 
     rope_scaling = getattr(config, "rope_scaling", None)
-    if hasattr(rope_scaling, "original_max_position_embeddings"):
-        old_max_length = getattr(rope_scaling, "original_max_position_embeddings", None)
+    if isinstance(rope_scaling, dict) and "original_max_position_embeddings" in rope_scaling:
+        old_max_length = rope_scaling["original_max_position_embeddings"]
     elif hasattr(config, "max_position_embeddings"):
         old_max_length = getattr(config, "max_position_embeddings", None)
     else:


### PR DESCRIPTION
# What does this PR do?

When resuming RoPE scaling on a model that's already scaled, the
`original_max_position_embeddings` wasn’t being picked up correctly. This patch fixes that.

For example, consider a model whose `config.json` is:

```json
{
  "max_position_embeddings": 65536,
  "rope_scaling": {
    "original_max_position_embeddings": 32768,
    "rope_type": "linear",
    "factor": 2.0
  }
}
```

If we extend this model to a sequence length of 128k, the patched RoPE config
would incorrectly become:

```json
{
  "max_position_embeddings": 131072,
  "rope_scaling": {
    "original_max_position_embeddings": 65536,
    "rope_type": "linear",
    "factor": 2.0
  }
}
```

The expected correct result is:

```json
{
  "max_position_embeddings": 131072,
  "rope_scaling": {
    "original_max_position_embeddings": 32768,
    "rope_type": "linear",
    "factor": 4.0
  }
}
```


## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?
