### PR TITLE
add deepspeed autotp config and example

### DIFF
--- a/examples/deepspeed/ds_z2_autotp_config.json
+++ b/examples/deepspeed/ds_z2_autotp_config.json
@@ -1,0 +1,32 @@
+{
+  "_comment": "suooprted model list: https://www.deepspeed.ai/tutorials/automatic-tensor-parallelism/#supported-models",
+  "train_batch_size": "auto",
+  "train_micro_batch_size_per_gpu": "auto",
+  "gradient_accumulation_steps": "auto",
+  "gradient_clipping": "auto",
+  "zero_allow_untested_optimizer": true,
+  "fp16": {
+    "enabled": "auto",
+    "loss_scale": 0,
+    "loss_scale_window": 1000,
+    "initial_scale_power": 16,
+    "hysteresis": 2,
+    "min_loss_scale": 1
+  },
+  "bf16": {
+    "enabled": "auto"
+  },
+  "zero_optimization": {
+    "stage": 2,
+    "allgather_partitions": true,
+    "allgather_bucket_size": 5e8,
+    "overlap_comm": false,
+    "reduce_scatter": true,
+    "reduce_bucket_size": 5e8,
+    "contiguous_gradients": true,
+    "round_robin_gradients": true
+  },
+  "tensor_parallel": {
+    "autotp_size": 2
+  }
+}

--- a/examples/train_full/qwen3_full_sft_autotp.yaml
+++ b/examples/train_full/qwen3_full_sft_autotp.yaml
@@ -1,0 +1,46 @@
+### model
+model_name_or_path: Qwen/Qwen3-32B
+trust_remote_code: true
+use_v1_kernels: true
+
+### method
+stage: sft
+do_train: true
+finetuning_type: full
+deepspeed: examples/deepspeed/ds_z2_autotp_config.json
+
+### dataset
+dataset: identity,alpaca_en_demo
+template: qwen3
+cutoff_len: 2048
+max_samples: 1000
+overwrite_cache: true
+preprocessing_num_workers: 16
+dataloader_num_workers: 4
+
+### output
+output_dir: saves/qwen3-32b/full/sft_autotp
+logging_steps: 1
+save_steps: 500
+plot_loss: true
+overwrite_output_dir: true
+save_only_model: false
+report_to: none  # choices: [none, wandb, tensorboard, swanlab, mlflow]
+
+### train
+per_device_train_batch_size: 4
+gradient_accumulation_steps: 1
+learning_rate: 1.0e-4
+num_train_epochs: 3.0
+lr_scheduler_type: cosine
+warmup_ratio: 0.1
+bf16: true
+ddp_timeout: 180000000
+resume_from_checkpoint: null
+
+### eval
+# eval_dataset: alpaca_en_demo
+# val_size: 0.1
+# per_device_eval_batch_size: 1
+# eval_strategy: steps
+# eval_steps: 500


### PR DESCRIPTION
# What does this PR do?
add deepspeed autotp config and example.
1. Currently, AutoTP only supports a limited number of models. You can view the list of supported models via the following link.
[supported-models](https://www.deepspeed.ai/tutorials/automatic-tensor-parallelism/#supported-models)
2. Currently, AutoTP only supports deepspeed zero0 and zero2, zero3 is not supported.
3. I tested the Qwen2-7B zero2+autotp, and compared to the zero2, it has about 7GB of HBM optimization.
4. I tested the Qwen2-7B zero2+autotp, and compared to the zero3, there is an approximately 15% performance improvement.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?

qwen3-32B 减层运行结果（zero2+autotp2）
<img width="771" height="819" alt="ScreenShot_20251211165243" src="https://github.com/user-attachments/assets/013f19b4-c831-4cbd-8fde-306c9ae4ff0d" />

