### PR TITLE
[feat] Models trained and inferred with FP8 are dequantized by default

### DIFF
--- a/src/llamafactory/model/model_utils/quantization.py
+++ b/src/llamafactory/model/model_utils/quantization.py
@@ -110,7 +110,7 @@ def configure_quantization(
             check_version("aqlm>=1.1.0", mandatory=True)
             quantization_config["bits"] = 2
 
-        if quant_method == QuantizationMethod.FP8 and is_trainable:
+        if quant_method == QuantizationMethod.FP8:
             quant_config = FineGrainedFP8Config(dequantize=True)
             init_kwargs["quantization_config"] = quant_config
 


### PR DESCRIPTION
# What does this PR do?

Resolving Errors When Loading a Trained Ministral-3 Model.

Fixes #9582

<img width="2142" height="694" alt="5ccbdd2f7a7e30a3eb2657f49d0a326d" src="https://github.com/user-attachments/assets/07213b12-4eb8-44ad-8773-2118e43fbd6f" />

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
