### PR TITLE
[data] Fix the video frame sampling issue #9620

### DIFF
--- a/src/llamafactory/data/mm_plugin.py
+++ b/src/llamafactory/data/mm_plugin.py
@@ -1624,7 +1624,7 @@ class Qwen3VLPlugin(Qwen2VLPlugin):
                 for video, duration in zip(videos["videos"], videos["durations"])
             ]
             mm_inputs.update(
-                video_processor(videos=videos["videos"], video_metadata=video_metadata, return_metadata=True)
+                video_processor(videos=videos["videos"], video_metadata=video_metadata, fps=getattr(processor, "video_fps", 2.0), return_metadata=True)
             )
             temporal_patch_size: int = getattr(image_processor, "temporal_patch_size", 2)
             if "second_per_grid_ts" in processor.model_input_names:


### PR DESCRIPTION
# What does this PR do?

Fixes #9620


Original implementation [Qwen3VLPlugin._get_mm_inputs](https://github.com/hiyouga/LLaMA-Factory/blob/5204cd2bca93b937ad888b68ec3ea76208f5e647/src/llamafactory/data/mm_plugin.py#L1626):
```
mm_inputs.update(
    video_processor(videos=videos["videos"], video_metadata=video_metadata, return_metadata=True)
)
```

[video_processing_qwen3_vl.sample_frames](https://github.com/huggingface/transformers/blob/dd24a80666b72c85f02c6cf9df18164cc174ab74/src/transformers/models/qwen3_vl/video_processing_qwen3_vl.py#L125) uses fps as the sampling parameter. If it is not provided, the default sampling parameter self.fps = 2 is used. When processing video stream data, [_get_video_sample_indices](https://github.com/hiyouga/LLaMA-Factory/blob/5204cd2bca93b937ad888b68ec3ea76208f5e647/src/llamafactory/data/mm_plugin.py#L248) performs video frame sampling first, so video_processing_qwen3_vl no longer needs to handle the sampling operation.

Therefore, the code is modified as follows:
```
mm_inputs.update(
    video_processor(videos=videos["videos"], video_metadata=video_metadata, fps=getattr(processor, "video_fps", 2.0), return_metadata=True)
)
```

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
