### PR TITLE
feat: add DLR-Web dataset for supervised fine-tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,7 @@ You also can add a custom chat template to [template.py](src/llamafactory/data/t
 - [Chinese-DeepSeek-R1-Distill (zh)](https://huggingface.co/datasets/Congliu/Chinese-DeepSeek-R1-Distill-data-110k-SFT)
 - [LLaVA mixed (en&zh)](https://huggingface.co/datasets/BUAADreamer/llava-en-zh-300k)
 - [Pokemon-gpt4o-captions (en&zh)](https://huggingface.co/datasets/jugg1024/pokemon-gpt4o-captions)
+- [DLR-Web (en)](https://huggingface.co/datasets/Attention1115/DLR-Web)
 - [Open Assistant (de)](https://huggingface.co/datasets/mayflowergmbh/oasst_de)
 - [Dolly 15k (de)](https://huggingface.co/datasets/mayflowergmbh/dolly-15k_de)
 - [Alpaca GPT4 (de)](https://huggingface.co/datasets/mayflowergmbh/alpaca-gpt4_de)

--- a/README_zh.md
+++ b/README_zh.md
@@ -436,6 +436,7 @@ https://github.com/user-attachments/assets/43b700c6-a178-41db-b1f8-8190a5d3fcfc
 - [Chinese-DeepSeek-R1-Distill (zh)](https://huggingface.co/datasets/Congliu/Chinese-DeepSeek-R1-Distill-data-110k-SFT)
 - [LLaVA mixed (en&zh)](https://huggingface.co/datasets/BUAADreamer/llava-en-zh-300k)
 - [Pokemon-gpt4o-captions (en&zh)](https://huggingface.co/datasets/jugg1024/pokemon-gpt4o-captions)
+- [DLR-Web (en)](https://huggingface.co/datasets/Attention1115/DLR-Web)
 - [Open Assistant (de)](https://huggingface.co/datasets/mayflowergmbh/oasst_de)
 - [Dolly 15k (de)](https://huggingface.co/datasets/mayflowergmbh/dolly-15k_de)
 - [Alpaca GPT4 (de)](https://huggingface.co/datasets/mayflowergmbh/alpaca-gpt4_de)

--- a/data/dataset_info.json
+++ b/data/dataset_info.json
@@ -471,6 +471,14 @@
   "ultrachat_de": {
     "hf_hub_url": "mayflowergmbh/ultra-chat_de"
   },
+  "dlr_web": {
+    "hf_hub_url": "Attention1115/DLR-Web",
+    "split": "full",
+    "columns": {
+      "prompt": "question",
+      "response": "response"
+    }
+  },
   "dpo_en_demo": {
     "file_name": "dpo_en_demo.json",
     "ranking": true,


### PR DESCRIPTION
### **Add a description**

This Pull Request introduces support for the **DLR-Web** dataset, a large-scale multidisciplinary reasoning dataset.

#### **Changes**

* Add the DLR-Web dataset entry to `README.md` and `README_zh.md`.
* Add the dataset configuration to `data/dataset_info.json` using the full split (1.66M samples).

# What does this PR do?

This PR adds the DLR-Web dataset to the supported list of supervised fine-tuning (SFT) datasets in LLaMA-Factory.

DLR-Web is a multidisciplinary reasoning dataset synthesized by Alibaba, containing 1.66 million high-quality samples. It is introduced in the paper: **"DESIGNER: Design-Logic-Guided Multidisciplinary Data Synthesis for LLM Reasoning"** ([arXiv:2508.12726](https://arxiv.org/abs/2508.12726)). For more details, please visit the [Project Page](https://attention-is-all-i-need.github.io/Design-Logic-Reasoning/).

**Key highlights of the dataset:**

* **Diversity and Difficulty**: Data analysis indicates that the questions synthesized by the DESIGNER method exhibit greater difficulty and diversity compared to those in existing baseline datasets.
* **Performance Gains**: We validate the synthesized data through supervised fine-tuning (SFT) on the Qwen3 and Llama3 model families. The data substantially enhances their multidisciplinary reasoning capabilities.
* **Superior Results**: Notably, by applying SFT on the base versions of these models using only our data, the resulting models surpass the performance of the official final models that have undergone the full post-training process.

#### **Dataset Source**

* **Hugging Face**: https://huggingface.co/datasets/Attention1115/DLR-Web


## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests? (N/A for data config)
