### PR TITLE
do_predict: fix the predict result matrix same as transformers.

### DIFF
--- a/scripts/vllm_infer.py
+++ b/scripts/vllm_infer.py
@@ -261,8 +261,9 @@ def vllm_infer(
 
         average_score = {}
         for task, scores in sorted(score_dict.items(), key=lambda x: x[0]):
-            print(f"predict_{task}: {sum(scores) / len(scores):.4f}")
-            average_score["predict_"+task] = sum(scores) / len(scores)
+            score = sum(scores) / len(scores) if scores else 0.0
+            print(f"predict_{task}: {score:.4f}")
+            average_score["predict_" + task] = score
 
         average_score['predict_model_preparation_time'] = preparation_time
         average_score['predict_runtime'] = predict_time


### PR DESCRIPTION
# What does this PR do?

Fixes # (issue)
https://github.com/hiyouga/LLaMA-Factory/issues/9556#issue-3679073308
https://github.com/hiyouga/LLaMA-Factory/issues/8657

I found that the do_predict method previously used in SFT in LLaMAFactory has become outdated. Moreover, when performing prediction after fine-tuning, validation is conducted in a data-parallel manner, which makes it impossible to run inference on a single GPU/NPU for 14B or larger models.

Following the recommendation:

Batch generation can be very slow. Consider using scripts/vllm_infer.py instead.

I switched to using vllm_infer.py for inference. However, it lacks the output of prediction metrics, which are important for many users.

Therefore, this PR enhances vllm_infer.py by incorporating metric-related logic from scripts/eval_bleu_rouge.py, and completes the reporting of the following performance metrics parameters:
```
{
           "predict_bleu-4": 4.349975,
           "predict_rouge-1": 21.873359375,
           "predict_rouge-2": 4.144340625,
           "predict_rouge-l": 10.83949375,
           "predict_runtime": 131.664,
           "predict_model_preparation_time": 0.0128,
           "predict_samples_per_second": 0.076,
           "predict_steps_per_second": 0.008
}
```

## Before submitting

- [√] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [√] Did you write any new necessary tests?
