### PR TITLE
[model] support for microsoft's Phi-4-mini

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ Read technical notes:
 | [PaliGemma/PaliGemma2](https://huggingface.co/google)             | 3B/10B/28B                       | paligemma            |
 | [Phi-3/Phi-3.5](https://huggingface.co/microsoft)                 | 4B/14B                           | phi                  |
 | [Phi-3-small](https://huggingface.co/microsoft)                   | 7B                               | phi_small            |
-| [Phi-4](https://huggingface.co/microsoft)                         | 14B                              | phi4                 |
+| [Phi-4-mini/Phi-4](https://huggingface.co/microsoft)              | 3.8B/14B                         | phi4_mini/phi4       |
 | [Pixtral](https://huggingface.co/mistralai)                       | 12B                              | pixtral              |
 | [Qwen (1-2.5) (Code/Math/MoE/QwQ)](https://huggingface.co/Qwen)   | 0.5B/1.5B/3B/7B/14B/32B/72B/110B | qwen                 |
 | [Qwen3 (MoE/Instruct/Thinking/Next)](https://huggingface.co/Qwen) | 0.6B/1.7B/4B/8B/14B/32B/80B/235B | qwen3/qwen3_nothink  |

--- a/README_zh.md
+++ b/README_zh.md
@@ -319,7 +319,7 @@ https://github.com/user-attachments/assets/43b700c6-a178-41db-b1f8-8190a5d3fcfc
 | [PaliGemma/PaliGemma2](https://huggingface.co/google)             | 3B/10B/28B                       | paligemma            |
 | [Phi-3/Phi-3.5](https://huggingface.co/microsoft)                 | 4B/14B                           | phi                  |
 | [Phi-3-small](https://huggingface.co/microsoft)                   | 7B                               | phi_small            |
-| [Phi-4](https://huggingface.co/microsoft)                         | 14B                              | phi4                 |
+| [Phi-4-mini/Phi-4](https://huggingface.co/microsoft)              | 3.8B/14B                         | phi4_mini/phi4       |
 | [Pixtral](https://huggingface.co/mistralai)                       | 12B                              | pixtral              |
 | [Qwen (1-2.5) (Code/Math/MoE/QwQ)](https://huggingface.co/Qwen)   | 0.5B/1.5B/3B/7B/14B/32B/72B/110B | qwen                 |
 | [Qwen3 (MoE/Instruct/Thinking/Next)](https://huggingface.co/Qwen) | 0.6B/1.7B/4B/8B/14B/32B/80B/235B | qwen3/qwen3_nothink  |

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -1910,6 +1910,17 @@ register_template(
 )
 
 
+register_template(
+    name="phi4_mini",
+    format_user=StringFormatter(slots=["<|user|>{{content}}<|end|><|assistant|>"]),
+    format_assistant=StringFormatter(slots=["{{content}}<|end|>"]),
+    format_system=StringFormatter(slots=["<|system|>{{content}}<|end|>"]),
+    format_tools=StringFormatter(slots=["<|tool|>{{content}}<|/tool|>"]),
+    stop_words=["<|end|>"],
+    replace_eos=True,
+)
+
+
 # copied from ministral template
 register_template(
     name="pixtral",

--- a/src/llamafactory/extras/constants.py
+++ b/src/llamafactory/extras/constants.py
@@ -2443,6 +2443,15 @@ register_model_group(
     template="phi4",
 )
 
+register_model_group(
+    models={
+        "Phi-4-3.8B-instruct": {
+            DownloadSource.DEFAULT: "microsoft/Phi-4-mini-instruct",
+            DownloadSource.MODELSCOPE: "LLM-Research/Phi-4-mini-instruct",
+        },
+    },
+    template="phi4_mini",
+)
 
 register_model_group(
     models={


### PR DESCRIPTION
### 🎯 Brief Introduction

Phi-4-mini-instruct is a lightweight open model built upon synthetic data and filtered publicly available websites - with a focus on high-quality, reasoning dense data. The model belongs to the Phi-4 model family and supports 128K token context length. The model underwent an enhancement process, incorporating both supervised fine-tuning and direct preference optimization to support precise instruction adherence and robust safety measures.

### Primary Use Cases

The model is intended for broad multilingual commercial and research use. The model provides uses for general purpose AI systems and applications which require:

- Memory/compute constrained environments
- Latency bound scenarios
- Strong reasoning (especially math and logic).

The model is designed to accelerate research on language and multimodal models, for use as a building block for generative AI powered features.

### Model

- [github](https://github.com/microsoft/PhiCookBook)
- [huggingface](https://huggingface.co/microsoft/Phi-4-mini-instruct)

### Usage for Training

Create a new file examples/train_lora/phi4_mini_lora_sft.yaml with the following content:

```
model_name_or_path: microsoft/Phi-4-mini-instruct

trust_remote_code: true

### method

stage: sft
do_train: true
finetuning_type: lora
lora_rank: 8
lora_target: all

### dataset

dataset: identity,alpaca_en_demo
template: phi4_mini

cutoff_len: 2048
max_samples: 1000
preprocessing_num_workers: 16
dataloader_num_workers: 4

### output

output_dir: saves/phi-4-mini-3.8B/lora/sft
logging_steps: 10
save_steps: 500
plot_loss: true
overwrite_output_dir: true
save_only_model: false
report_to: none  # choices: [none, wandb, tensorboard, swanlab, mlflow]

### train

per_device_train_batch_size: 1
gradient_accumulation_steps: 8
learning_rate: 1.0e-4
num_train_epochs: 3.0
lr_scheduler_type: cosine
warmup_ratio: 0.1
bf16: true
ddp_timeout: 180000000
resume_from_checkpoint: null

### eval

# eval_dataset: alpaca_en_demo

# val_size: 0.1

# per_device_eval_batch_size: 1

# eval_strategy: steps

# eval_steps: 500
```

### used

```
1 gpu

DISABLE_VERSION_CHECK=1 llamafactory-cli train examples/train_lora/phi4_mini_lora_sft.yaml
 1 node

DISABLE_VERSION_CHECK=1 FORCE_TORCHRUN=1 llamafactory-cli train examples/train_lora/phi4_mini_lora_sft.yaml
```

### result

<img width="1427" height="330" alt="1" src="https://github.com/user-attachments/assets/d43825d0-c18f-4869-a65e-8eeb42f18567" />

template: phi

<img width="640" height="480" alt="phi_mini" src="https://github.com/user-attachments/assets/b70498b1-593a-44d6-93a5-c278efd61488" />

template: phi4_mini

<img width="640" height="480" alt="phi4_mini" src="https://github.com/user-attachments/assets/43eabd5f-246f-4b8d-bc8a-77c1b03c447b" />

We conducted a comparison of the loss metrics between the `phi` template and `phi4_mini` template. The results indicate that **the ​`phi4_mini` ​template is better suited for the training process of the current ​`phi4_mini` ​model** (demonstrating better initial loss convergence and format compatibility with the target model.
