### PR TITLE
[v1] fix kernel moe patch

### DIFF
--- a/src/llamafactory/v1/plugins/model_plugins/kernels/ops/mlp/npu_fused_moe.py
+++ b/src/llamafactory/v1/plugins/model_plugins/kernels/ops/mlp/npu_fused_moe.py
@@ -324,7 +324,7 @@ class NpuFusedMoEKernel(BaseKernel):
         if not cls.check_deps():
             raise RuntimeError("torch_npu is not available but NpuMoEFusedMoEKernel was called.")
 
-        archs = getattr(model.config, "architectures", [])
+        archs = getattr(model.config, "architectures", None) or []
         target_moe_mapping = None
         for arch in archs:
             if arch in kernel_moe_mapping:


### PR DESCRIPTION
# What does this PR do?

`getattr(config, "architectures", [])` may return None instead of the fallback value.

In transformers, architectures is defined on PretrainedConfig but defaults to None when not explicitly set by the model.

Therefore, the attribute exists, but its value is None, so getattr does not trigger the default argument.

```
>>> from transformers import AutoModelForTextToWaveform
>>> model = AutoModelForTextToWaveform.from_pretrained("./Qwen3-Omni-30B-A3B-Instruct")
>>> model = getattr(model, "thinker")
>>> getattr(model.config, "architectures", [])
>>> hasattr(model.config, "architectures")
True
>>> getattr(model.config, "architectures", None) or []
[]
```

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?
