### PR TITLE
add dpo/kto fsdp fsdp2 support

### DIFF
--- a/src/llamafactory/train/dpo/trainer.py
+++ b/src/llamafactory/train/dpo/trainer.py
@@ -25,8 +25,8 @@ import torch
 import torch.nn.functional as F
 from transformers import Trainer
 from trl import DPOTrainer
+from trl.models.utils import prepare_deepspeed, prepare_fsdp
 from trl.trainer import disable_dropout_in_model
-from trl.models.utils import prepare_fsdp, prepare_deepspeed
 from typing_extensions import override
 
 from ...extras.constants import IGNORE_INDEX
@@ -100,6 +100,7 @@ class CustomDPOTrainer(DPOTrainer):
             elif self.is_fsdp_enabled:
                 if self.accelerator.is_fsdp2:
                     from accelerate.utils.fsdp_utils import fsdp2_prepare_model
+
                     self.ref_model = fsdp2_prepare_model(self.accelerator, self.ref_model)
                 else:
                     self.ref_model = prepare_fsdp(self.ref_model, self.accelerator)

--- a/src/llamafactory/train/kto/trainer.py
+++ b/src/llamafactory/train/kto/trainer.py
@@ -24,8 +24,8 @@ from typing import TYPE_CHECKING, Literal, Optional, Union
 import torch
 from transformers import Trainer
 from trl import KTOTrainer
+from trl.models.utils import prepare_deepspeed, prepare_fsdp
 from trl.trainer import disable_dropout_in_model
-from trl.models.utils import prepare_fsdp, prepare_deepspeed
 from typing_extensions import override
 
 from ...extras.constants import IGNORE_INDEX
@@ -102,6 +102,7 @@ class CustomKTOTrainer(KTOTrainer):
             elif self.is_fsdp_enabled:
                 if self.accelerator.is_fsdp2:
                     from accelerate.utils.fsdp_utils import fsdp2_prepare_model
+
                     self.ref_model = fsdp2_prepare_model(self.accelerator, self.ref_model)
                 else:
                     self.ref_model = prepare_fsdp(self.ref_model, self.accelerator)


### PR DESCRIPTION
# What does this PR do?
add dpo/kto fsdp support

Fixes #10126

- Use `trl.models.utils.prepare_deepspeed` instead of `trl.trainer.utils`, as the latter should not be used on the `ref_model`.
- Added `prepare_fsdp` and `fsdp2_prepare_model`; the initialization methods for fsdp1 and fsdp2 are different.


## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
