### PR TITLE
Fix : add visual.pos_embed to Qwen3-VL visual model keys

### DIFF
--- a/src/llamafactory/model/model_utils/visual.py
+++ b/src/llamafactory/model/model_utils/visual.py
@@ -356,7 +356,7 @@ _register_composite_model(
 _register_composite_model(
     model_type="qwen3_vl",
     projector_key="visual.merger",
-    vision_model_keys=["visual.patch_embed", "visual.blocks", "visual.deepstack_merger_list"],
+    vision_model_keys=["visual.pos_embed", "visual.patch_embed", "visual.blocks", "visual.deepstack_merger_list"],
     language_model_keys=["language_model", "lm_head"],
     lora_conflict_keys=["patch_embed"],
 )
@@ -365,7 +365,7 @@ _register_composite_model(
 _register_composite_model(
     model_type="qwen3_vl_moe",
     projector_key="visual.merger",
-    vision_model_keys=["visual.patch_embed", "visual.blocks", "visual.deepstack_merger_list"],
+    vision_model_keys=["visual.pos_embed", "visual.patch_embed", "visual.blocks", "visual.deepstack_merger_list"],
     language_model_keys=["language_model", "lm_head"],
     lora_conflict_keys=["patch_embed"],
 )
@@ -374,7 +374,7 @@ _register_composite_model(
 _register_composite_model(
     model_type="qwen3_omni_moe_thinker",
     projector_key="visual.merger",
-    vision_model_keys=["visual.patch_embed", "visual.blocks", "visual.deepstack_merger_list", "audio_tower"],
+    vision_model_keys=["visual.pos_embed", "visual.patch_embed", "visual.blocks", "visual.deepstack_merger_list", "audio_tower"],
     language_model_keys=["model", "lm_head"],
     lora_conflict_keys=["patch_embed"],
 )


### PR DESCRIPTION
# What does this PR do?
This PR fixes an issue where Qwen3-VL's visual.pos_embed modules were unintentionally trained when freeze_vision_tower=True (the default setting).

# Reproduction script
```
from transformers import Qwen3VLForConditionalGeneration
import torch

model_original = Qwen3VLForConditionalGeneration.from_pretrained(
    "Qwen/Qwen3-VL-8B-Instruct"
)
model_trained = Qwen3VLForConditionalGeneration.from_pretrained(
    "TRAINED_DIR"
)

def module_weight_dict(model):
    return {name: param for name, param in model.named_parameters()}

w_trained = module_weight_dict(model_trained.model.visual)
w_original = module_weight_dict(model_original.model.visual)

for k in w_trained:
    if isinstance(w_trained[k], torch.Tensor):
        diff = (w_trained[k] != w_original[k]).count_nonzero()
        if diff > 0:
            print(f"{k} has {diff} non-zero elements")
```

```
pos_embed.weight has 2408 non-zero elements
```

# Fixes
When freeze_vision_tower=True, model.visual.pos_embed is not frozen which is not what the freeze_vision_tower arg intended.

Freeze model.visual.pos_embed by adding visual_model_keys to Qwen3-VL variants.

## Before submitting

- [v] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [v] Did you write any new necessary tests?
