### PR TITLE
Fix race condition in LoggerHandler during multi-GPU training

### DIFF
--- a/src/llamafactory/extras/logging.py
+++ b/src/llamafactory/extras/logging.py
@@ -41,12 +41,13 @@ class LoggerHandler(logging.Handler):
             datefmt="%Y-%m-%d %H:%M:%S",
         )
         self.setLevel(logging.INFO)
+        self.thread_pool = ThreadPoolExecutor(max_workers=1)
         os.makedirs(output_dir, exist_ok=True)
         self.running_log = os.path.join(output_dir, RUNNING_LOG)
-        if os.path.exists(self.running_log):
+        try:
             os.remove(self.running_log)
-
-        self.thread_pool = ThreadPoolExecutor(max_workers=1)
+        except OSError:
+            pass
 
     def _write_log(self, log_entry: str) -> None:
         with open(self.running_log, "a", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary

- Fix TOCTOU race condition in `LoggerHandler.__init__()` where multiple ranks race on deleting `running_log.txt` during distributed training, causing `FileNotFoundError`
- Move `thread_pool` initialization before file operations to prevent secondary `AttributeError` in `close()` when `__init__` fails

## Problem

In multi-GPU (DDP) training with LLaMA Board enabled, each rank initializes a `LoggerHandler` that tries to clean up `running_log.txt`. The previous pattern:

```python
if os.path.exists(self.running_log):
    os.remove(self.running_log)
```

is a classic [TOCTOU race condition](https://en.wikipedia.org/wiki/Time-of-check_to_time-of-use) — multiple ranks check existence simultaneously, all see `True`, then one deletes successfully while others crash with `FileNotFoundError`.

When `__init__` fails before `self.thread_pool` is assigned, the logging shutdown handler calls `close()` which crashes with `AttributeError: 'LoggerHandler' object has no attribute 'thread_pool'`.

## Fix

1. Replace `os.path.exists()` + `os.remove()` with a single `try/except OSError` around `os.remove()` — atomic and race-safe
2. Initialize `self.thread_pool` before the file operation so `close()` always works

Fixes #9819