### PR TITLE
[model] support GLM-OCR SFT

### DIFF
--- a/src/llamafactory/data/collator.py
+++ b/src/llamafactory/data/collator.py
@@ -213,6 +213,7 @@ class MultiModalDataCollatorForSeq2Seq(DataCollatorForSeq2Seq):
             and getattr(self.model.config, "model_type", None)
             in [
                 "glm4v",
+                "glm_ocr",
                 "Keye",
                 "qwen2_vl",
                 "qwen2_5_vl",

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -1061,6 +1061,22 @@ register_template(
 )
 
 
+# copied from glm4 template
+register_template(
+    name="glm_ocr",
+    format_user=StringFormatter(slots=["<|user|>\n{{content}}<|assistant|>"]),
+    format_assistant=StringFormatter(slots=["\n{{content}}"]),
+    format_system=StringFormatter(slots=["<|system|>\n{{content}}"]),
+    format_function=FunctionFormatter(slots=["{{content}}"], tool_format="glm4"),
+    format_observation=StringFormatter(slots=["<|observation|>\n{{content}}<|assistant|>"]),
+    format_tools=ToolFormatter(tool_format="glm4"),
+    format_prefix=EmptyFormatter(slots=["[gMASK]<sop>"]),
+    stop_words=["<|user|>", "<|observation|>"],
+    efficient_eos=True,
+    mm_plugin=get_mm_plugin(name="glm4v", image_token="<|image|>", video_token="<|video|>"),
+)
+
+
 # copied from glm4_moe template
 register_template(
     name="glm4_7",

--- a/src/llamafactory/extras/constants.py
+++ b/src/llamafactory/extras/constants.py
@@ -952,6 +952,18 @@ register_model_group(
 
 register_model_group(
     models={
+        "GLM-OCR": {
+            DownloadSource.DEFAULT: "zai-org/GLM-OCR",
+            DownloadSource.MODELSCOPE: "ZhipuAI/GLM-OCR",
+        },
+    },
+    template="glm_ocr",
+    multimodal=True,
+)
+
+
+register_model_group(
+    models={
         "GLM-Z1-0414-9B-Chat": {
             DownloadSource.DEFAULT: "zai-org/GLM-Z1-9B-0414",
             DownloadSource.MODELSCOPE: "ZhipuAI/GLM-Z1-9B-0414",

--- a/src/llamafactory/model/model_utils/visual.py
+++ b/src/llamafactory/model/model_utils/visual.py
@@ -240,6 +240,15 @@ _register_composite_model(
 
 
 _register_composite_model(
+    model_type="glm_ocr",
+    projector_key="visual.merger",
+    vision_model_keys=["visual.patch_embed", "visual.blocks"],
+    language_model_keys=["language_model", "lm_head"],
+    lora_conflict_keys=["patch_embed"],
+)
+
+
+_register_composite_model(
     model_type="internvl",
 )
 


### PR DESCRIPTION
# Summary
- Add GLM-OCR (0.9B lightweight OCR model) registration with HuggingFace (zai-org/GLM-OCR) and ModelScope (ZhipuAI/GLM-OCR) sources
- Add glm_ocr chat template reusing the GLM-4 conversation format ([gMASK]<sop> prefix, <|user|>/<|assistant|> roles) with glm4v multimodal plugin for image processing
- Add composite model registration for glm_ocr model type with correct vision/projector/language model key mapping for freeze and LoRA support
- Add mRoPE 3D position embedding support for glm_ocr model type in data collator

# Details

GLM-OCR is a lightweight multimodal OCR model (model_type: glm_ocr, 0.9B parameters) featuring a CogViT visual encoder, a lightweight cross-modal connector (visual.merger), and a GLM-0.5B language decoder. It uses the Glm46VProcessor / Glm46VImageProcessor and 3D mRoPE position embeddings, sharing the same multimodal processing pipeline as GLM-4.6V.

GLM-OCR requires transformers >= 5.1.0.