### PR TITLE
Add DeepSpeed Z3 leaf module for Qwen3-Next

### DIFF
--- a/src/llamafactory/model/model_utils/moe.py
+++ b/src/llamafactory/model/model_utils/moe.py
@@ -142,6 +142,10 @@ def add_z3_leaf_module(model: "PreTrainedModel") -> None:
 
         _set_z3_leaf_modules(model, [Qwen3OmniMoeThinkerTextSparseMoeBlock])
 
+    if model_type == "qwen3_next":
+        from transformers.models.qwen3_next.modeling_qwen3_next import Qwen3NextSparseMoeBlock
+
+        _set_z3_leaf_modules(model, [Qwen3NextSparseMoeBlock])
 
 def configure_moe(config: "PretrainedConfig", model_args: "ModelArguments", is_trainable: bool) -> None:
     if not is_trainable or not model_args.moe_aux_loss_coef:


### PR DESCRIPTION
## Summary
- Register `Qwen3NextSparseMoeBlock` as a DeepSpeed ZeRO-3 leaf module for `qwen3_next` model type
- Prevents Z3 from incorrectly partitioning MoE expert blocks during training, consistent with how other MoE models (qwen3_moe, mixtral, deepseek_v3, etc.) are handled

## Details
Qwen3-Next (`Qwen/Qwen3-Next-80B-A3B-Instruct`) is a hybrid MoE model (512 experts, 10 active per token) with 3D packed `nn.Parameter` for expert weights. Without the leaf module registration, DeepSpeed Z3 attempts to partition the expert block internals, which breaks gradient computation during training.

Requires `transformers >= 5.0.0` (model was added in v5.0).

## Test plan
- [x] Verified LoRA SFT training with DeepSpeed Z3 on 4xH200 — loss converges normally
- [ ] CI tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)