### PR TITLE
Fix #10179: 开启streaming模式后 GPU训练效率很低 训练很慢

### DIFF
--- a/src/llamafactory/data/loader.py
+++ b/src/llamafactory/data/loader.py
@@ -251,6 +251,10 @@ def _get_preprocessed_dataset(
             load_from_cache_file=(not data_args.overwrite_cache) or (training_args.local_process_index != 0),
             desc="Running tokenizer on dataset",
         )
+    else:
+        kwargs = dict(
+            num_proc=data_args.preprocessing_num_workers,
+        )
 
     dataset = dataset.map(
         dataset_processor.preprocess_dataset,


### PR DESCRIPTION
Fixes #10179

## Summary
This PR fixes: 开启streaming模式后 GPU训练效率很低 训练很慢

## Changes
```
src/llamafactory/data/loader.py | 4 ++++
 1 file changed, 4 insertions(+)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license (contributor license agreement).