### PR TITLE
upgrade to ROCm 7.2 base image, drop PyTorch reinstall

### DIFF
--- a/docker/docker-rocm/Dockerfile
+++ b/docker/docker-rocm/Dockerfile
@@ -33,7 +33,7 @@ RUN pip config set global.index-url "${PIP_INDEX}" && \
 COPY . /app
 
 # Install LLaMA Factory (use base image's PyTorch/ROCm; do not reinstall)
-RUN pip install --no-cache-dir -e . && \
+RUN pip install --no-cache-dir -e . --pre && \
     pip install --no-cache-dir -r requirements/deepspeed.txt -r requirements/liger-kernel.txt -r requirements/bitsandbytes.txt
 
 # Rebuild flash attention


### PR DESCRIPTION
# What does this PR do?

Upgrade ROCm Docker to 7.2 base image and simplify install

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?

## Description

### Summary

* Updates the ROCm Docker setup to use a current ROCm base image,
* align with LLaMA Factory’s Python requirement,
* and avoid reinstalling PyTorch.

### Motivation

The previous ROCm image was outdated and caused training examples to fail (e.g. bf16/GPU validation errors). The new image provides a compatible Python version, up-to-date PyTorch/ROCm, and a simpler, more reliable install path.

### Changes

* Base image: `rocm/pytorch:rocm6.4.1_ubuntu22.04_py3.10_...` → `rocm/pytorch:rocm7.2_ubuntu24.04_py3.12_pytorch_release_2.7.1`
* Python: New image uses Python 3.12, matching `requires-python = ">=3.11.0"` in `pyproject.toml`.
* PyTorch: Use the PyTorch already in the base image; removed PyTorch reinstall and the `PYTORCH_INDEX` build arg to prevent version/backend mismatches.

### Testing

* Training runs successfully in the new image.
* Test suite: 74 passed, 111 skipped (e.g. tests that require cpu/mps while running on CUDA/ROCm), 3 xfailed, 1 xpassed. Skips and xfails match known limitations (device requirements, gated models, platform-specific issues), not regressions from this change.