### PR TITLE
fix: qwen3.5 projector path

### DIFF
--- a/src/llamafactory/model/model_utils/visual.py
+++ b/src/llamafactory/model/model_utils/visual.py
@@ -390,7 +390,7 @@ _register_composite_model(
         "visual.deepstack_merger_list",
         "audio_tower",
     ],
-    language_model_keys=["model", "lm_head"],
+    language_model_keys=["language_model", "lm_head"],
     lora_conflict_keys=["patch_embed"],
 )
 
@@ -398,7 +398,7 @@ _register_composite_model(
 _register_composite_model(
     model_type="qwen3_5",
     projector_key="model.visual.merger",
-    vision_model_keys=["model.visual.pos_embed", "model.visual.patch_embed", "model.visual.blocks"],
+    vision_model_keys=["visual.pos_embed", "visual.patch_embed", "visual.blocks"],
     language_model_keys=["language_model", "lm_head"],
     lora_conflict_keys=["patch_embed"],
 )
@@ -407,7 +407,7 @@ _register_composite_model(
 _register_composite_model(
     model_type="qwen3_5_moe",
     projector_key="model.visual.merger",
-    vision_model_keys=["model.visual.pos_embed", "model.visual.patch_embed", "model.visual.blocks"],
+    vision_model_keys=["visual.pos_embed", "visual.patch_embed", "visual.blocks"],
     language_model_keys=["language_model", "lm_head"],
     lora_conflict_keys=["patch_embed"],
 )


### PR DESCRIPTION
## What does this PR do?

Fixes incorrect Qwen3.5 projector path resolution during training patching.

`autocast_projector_dtype` resolves projector modules using `projector_key`.
For `qwen3_5` / `qwen3_5_moe`, the correct path is `model.visual.merger` (instead of `visual.merger`).
The previous mapping caused the following error during fine-tuning:

`AttributeError: 'Qwen3_5ForConditionalGeneration' object has no attribute 'visual'`

---

## Changes

- Update `projector_key` to `model.visual.merger` for:
  - `qwen3_5`
  - `qwen3_5_moe`

## Checks
**Before fix** (initialization failure):
<img width="1090" height="810" alt="image" src="https://github.com/user-attachments/assets/5770a090-9a74-4b3a-a4a5-6e01137181c2" />
**After fix** (projector correctly resolved and frozen):
<img width="1068" height="378" alt="image" src="https://github.com/user-attachments/assets/0a9f880c-b7e9-4770-849a-c29a5c9141de" />

---

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?