### PR TITLE
fix: get ray head ip

### DIFF
--- a/src/llamafactory/train/trainer_utils.py
+++ b/src/llamafactory/train/trainer_utils.py
@@ -50,6 +50,7 @@ if is_apollo_available():
 
 if is_ray_available():
     import ray
+    from ray.util.state import list_nodes
     from ray.util.placement_group import PlacementGroup, placement_group
     from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
@@ -941,7 +942,7 @@ def get_ray_remote_config_for_worker(
 
 def get_ray_head_node_ip() -> str:
     r"""Get the IP address of the Ray head node."""
-    head_ip = next(node["NodeManagerAddress"] for node in ray.nodes() if node.get("IsHead", False))
+    head_ip = next(node["node_ip"] for node in list_nodes() if node.get("is_head_node", False))
     return head_ip
 
 


### PR DESCRIPTION
# What does this PR do?

When applying the latest `ray==2.54.0` lib for distributed training using LlamaFactory, the following bugs occur after setting up the Ray runtime:

```text
Traceback (most recent call last):
  File "/root/miniconda3/envs/demo/bin/llamafactory-cli", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/mnt/ali-sh-1/dataset/zeus/ylqiu/codes/demo_exp/LlamaFactory/src/llamafactory/cli.py", line 24, in main
    launcher.launch()
  File "/mnt/ali-sh-1/dataset/zeus/ylqiu/codes/demo_exp/LlamaFactory/src/llamafactory/launcher.py", line 157, in launch                                   6
    run_exp()
  File "/mnt/ali-sh-1/dataset/zeus/ylqiu/codes/demo_exp/LlamaFactory/src/llamafactory/train/tuner.py", line 123, in run_exp
    _ray_training_function(ray_args, config={"args": args, "callbacks": callbacks})
  File "/mnt/ali-sh-1/dataset/zeus/ylqiu/codes/demo_exp/LlamaFactory/src/llamafactory/train/tuner.py", line 274, in _ray_training_function
    master_addr = get_ray_head_node_ip()
                  ^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/ali-sh-1/dataset/zeus/ylqiu/codes/demo_exp/LlamaFactory/src/llamafactory/train/trainer_utils.py", line 945, in get_ray_head_node_ip
    head_ip = next(node["NodeManagerAddress"] for node in ray.nodes() if node.get("IsHead", False))
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
StopIteration
```

This PR fixes it by updating the corresponding `get_ray_head_node_ip` func.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?

