### PR TITLE
fix: Fix compatibility issue with HuggingFace Dataset Column when sav…

### DIFF
--- a/src/llamafactory/train/sft/trainer.py
+++ b/src/llamafactory/train/sft/trainer.py
@@ -216,9 +216,9 @@ class CustomSeq2SeqTrainer(Seq2SeqTrainer):
                 preds[i] = np.concatenate((preds[i][pad_len[0] :], preds[i][: pad_len[0]]), axis=-1)
         
         input_ids_column = dataset["input_ids"]
-        if hasattr(input_ids_column, 'to_pylist'):
+        try:
             input_ids_list = input_ids_column.to_pylist()
-        else:
+        except AttributeError:
             input_ids_list = list(input_ids_column)
 
         decoded_inputs = self.processing_class.batch_decode(input_ids_list, skip_special_tokens=False)


### PR DESCRIPTION
# [Fix] Fix compatibility issue with HuggingFace Dataset Column when saving predictions

## Problem
When using a HuggingFace Dataset for evaluation, saving predictions fails with:

```
TypeError: argument 'ids': 'list' object cannot be interpreted as an integer
```

Line 179 in `trainer.py`:
```python
decoded_inputs = self.processing_class.batch_decode(dataset["input_ids"], skip_special_tokens=False)
```

## Root Cause
`dataset["input_ids"]` returns a `Column` object, not a Python list. `batch_decode()` expects a list.

## Changes

### Before
```python
decoded_inputs = self.processing_class.batch_decode(dataset["input_ids"], skip_special_tokens=False)
```

### After
```python
input_ids_column = dataset["input_ids"]
if hasattr(input_ids_column, 'to_pylist'):
    input_ids_list = input_ids_column.to_pylist()
else:
    input_ids_list = list(input_ids_column)

decoded_inputs = self.processing_class.batch_decode(input_ids_list, skip_special_tokens=False)
```

## Files Changed
`src/llamafactory/train/sft/trainer.py`

## Impact
Affects users using HuggingFace Dataset (including local files auto-converted to Dataset).