### PR TITLE
docs: fix Python version requirement from 3.10 to >=3.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,7 +473,7 @@ huggingface-cli login
 
 | Mandatory    | Minimum | Recommend |
 | ------------ | ------- | --------- |
-| python       | 3.9     | 3.10      |
+| python       | 3.11     | >=3.11   |
 | torch        | 2.0.0   | 2.6.0     |
 | torchvision  | 0.15.0  | 0.21.0    |
 | transformers | 4.49.0  | 4.50.0    |

--- a/README_zh.md
+++ b/README_zh.md
@@ -475,7 +475,7 @@ huggingface-cli login
 
 | 必需项        | 至少     | 推荐      |
 | ------------ | ------- | --------- |
-| python       | 3.9     | 3.10      |
+| python       | 3.11     | >=3.11   |
 | torch        | 2.0.0   | 2.6.0     |
 | torchvision  | 0.15.0  | 0.21.0    |
 | transformers | 4.49.0  | 4.50.0    |


### PR DESCRIPTION
# What does this PR do?
This PR fixes incorrect Python version requirement in the documentation.
The README states that Python 3.10 is supported, but the actual installation requires `>=3.11.0`. Attempting to install with Python 3.10.19 results in the following error:

```bash
(test_llama) C:\Users\ll0v0ll\LlamaFactory>pip install -e .
Obtaining file:///C:/Users/ll0v0ll/LlamaFactory
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... done
  Installing backend dependencies ... done
  Preparing editable metadata (pyproject.toml) ... done
INFO: pip is looking at multiple versions of llamafactory to determine which version is compatible with other requirements. This could take a while.
ERROR: Package 'llamafactory' requires a different Python: 3.10.19 not in '>=3.11.0'
```

After upgrading to Python 3.11, the installation completed successfully.
Fixes # (issue)


## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?

N/A - This is a documentation fix only, no code changes required.