### PR TITLE
fix: convert filter() to list in read_cloud_json to fix broken empty-check

### DIFF
--- a/src/llamafactory/data/data_utils.py
+++ b/src/llamafactory/data/data_utils.py
@@ -196,7 +196,7 @@ def read_cloud_json(cloud_path: str) -> list[Any]:
 
     # filter out non-JSON files
     files = [x["Key"] for x in fs.listdir(cloud_path)] if fs.isdir(cloud_path) else [cloud_path]
-    files = filter(lambda file: file.endswith(".json") or file.endswith(".jsonl"), files)
+    files = list(filter(lambda file: file.endswith(".json") or file.endswith(".jsonl"), files))
     if not files:
         raise ValueError(f"No JSON/JSONL files found in the specified path: {cloud_path}.")
 


### PR DESCRIPTION
## Summary

Fix a bug in `read_cloud_json()` in `src/llamafactory/data/data_utils.py` where `filter()` returns a lazy iterator that is always truthy in a boolean context.

### Bug

```python
files = filter(lambda file: file.endswith(".json") or file.endswith(".jsonl"), files)
if not files:  # <-- This is always False because filter objects are truthy
    raise ValueError(...)
```

Python's `filter()` returns an iterator object, not a list. Iterator objects are always truthy regardless of whether they yield any elements. This means:

1. **The emptiness check never works**: `if not files:` is always `False`, so the descriptive `ValueError` for missing JSON/JSONL files is never raised.
2. **Silent failure**: When no JSON/JSONL files exist in the cloud path, instead of raising a clear error, the function silently returns an empty list `[]`.

### Fix

Convert the `filter()` result to a `list` so that the emptiness check works correctly:

```python
files = list(filter(lambda file: file.endswith(".json") or file.endswith(".jsonl"), files))
if not files:  # <-- Now correctly evaluates to True when no files match
    raise ValueError(...)
```

## Test plan

- Verify that `read_cloud_json()` raises `ValueError` when pointed at a cloud path with no `.json`/`.jsonl` files
- Verify that `read_cloud_json()` still works correctly when valid JSON/JSONL files exist
