### PR TITLE
fix(mm): fallback to audio_processor when feature_extractor is missing

### DIFF
--- a/src/llamafactory/data/mm_plugin.py
+++ b/src/llamafactory/data/mm_plugin.py
@@ -161,7 +161,9 @@ class MMPluginMixin:
         video_processor: BaseImageProcessor = getattr(
             processor, "video_processor", getattr(processor, "image_processor", None)
         )
-        feature_extractor: SequenceFeatureExtractor = getattr(processor, "feature_extractor", None)
+        feature_extractor: SequenceFeatureExtractor = getattr(processor, "feature_extractor", None) or getattr(
+            processor, "audio_processor", None
+        )
         if len(images) != 0 and self.image_token is None:
             raise ValueError(
                 "This model does not support image input. Please check whether the correct `template` is used."
@@ -390,7 +392,9 @@ class MMPluginMixin:
                 mm_inputs.update(video_processor(videos, return_tensors="pt"))
 
         if len(audios) != 0:
-            feature_extractor: SequenceFeatureExtractor = getattr(processor, "feature_extractor", None)
+            feature_extractor: SequenceFeatureExtractor = getattr(processor, "feature_extractor", None) or getattr(
+                processor, "audio_processor", None
+            )
             audios = self._regularize_audios(
                 audios,
                 sampling_rate=getattr(processor, "audio_sampling_rate", 16000),
@@ -1876,7 +1880,9 @@ class Qwen2OmniPlugin(Qwen2VLPlugin):
     ) -> dict[str, "torch.Tensor"]:
         image_processor: BaseImageProcessor = getattr(processor, "image_processor", None)
         video_processor: BaseVideoProcessor = getattr(processor, "video_processor", None)
-        feature_extractor: SequenceFeatureExtractor = getattr(processor, "feature_extractor", None)
+        feature_extractor: SequenceFeatureExtractor = getattr(processor, "feature_extractor", None) or getattr(
+            processor, "audio_processor", None
+        )
         mm_inputs = {}
         if len(images) != 0:
             images = self._regularize_images(


### PR DESCRIPTION
## Summary
Training **MiniCPM-o-4_5** with multimodal samples that include both **video** and **audio** can fail during dataset preprocessing with:

```
ValueError: Audio feature extractor was not found, please check and update your model file.
```

This happens when the loaded HF processor does not expose an attribute named `feature_extractor` (e.g. some processor implementations / newer Transformers versions), even though an audio processor is available under `audio_processor`.

## Repro (high level)
- Model: `openbmb/MiniCPM-o-4_5`
- Template: `minicpm_o`
- Dataset: messages contain `<video><audio>` placeholders and provide both `videos` and `audios` columns.

## Root cause
`src/llamafactory/data/mm_plugin.py` assumes the audio feature extractor is always available as `processor.feature_extractor`:
- `MMPluginMixin._validate_input`
- `MMPluginMixin._get_mm_inputs` (audio branch)
- `Qwen2OmniPlugin._get_mm_inputs` (audio branch)

When `feature_extractor` is missing, these code paths treat it as unsupported audio input and raise.

## Fix
Fallback to `processor.audio_processor` when `processor.feature_extractor` is not present:

```python
getattr(processor, "feature_extractor", None) or getattr(processor, "audio_processor", None)
```

Applied at the three access sites listed above.

## Impact
- Only affects runs that actually use audio inputs (`<audio>` / `audios` present).
- No behavior change when `feature_extractor` already exists.