### PR TITLE
fix(template): correct gpt_oss format_assistant

### DIFF
--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -1113,7 +1113,7 @@ register_template(
 register_template(
     name="gpt_oss",
     format_user=StringFormatter(slots=["<|start|>user<|message|>{{content}}<|end|><|start|>assistant"]),
-    format_assistant=StringFormatter(slots=["{{content}}<|end|>"]),
+    format_assistant=StringFormatter(slots=["{{content}}"]),
     format_system=StringFormatter(slots=["<|start|>system<|message|>{{content}}<|end|>"]),
     default_system="You are ChatGPT, a large language model trained by OpenAI.",
     thought_words=("<|channel|>analysis<|message|>", "<|end|><|start|>assistant<|channel|>final<|message|>"),


### PR DESCRIPTION
# What does this PR do?

Fix gpt_oss Template - Detailed Description

## Problem

When deploying models trained with LlamaFactory's gpt_oss template, the inference server returns error:

```json
{
  "error": {
    "message": "Unexpected token 200002 while expecting start token 200006",
    "type": "Internal Server Error",
    "param": null,
    "code": 500
  }
}
```

Error originates from openai_harmony library's StreamableParser during response parsing.

## Root Cause

LlamaFactory's template generates incorrect token sequence at the end of assistant responses.

**Original GPT-OSS model output** (correct):
```
...assistant<|channel|>final<|message|>2 + 2 equals 4.<|return|>
                                                      ^^^^^^^^^
Token sequence: ... → 200002 (<|return|>)
```

**LlamaFactory trained model output** (incorrect):
```
...assistant<|channel|>final<|message|>The answer is 5!<|end|><|return|>
                                                        ^^^^^^^^^^^^^^
Token sequence: ... → 200007 (<|end|>) → 200002 (<|return|>)
```

The extra `<|end|>` token (200007) before `<|return|>` (200002) violates the harmony format specification and causes the parser to fail.

## Solution

Remove `<|end|>` from format_assistant to match the official format:

```python
# Before (line 1116)
format_assistant=StringFormatter(slots=["{{content}}<|end|>"])

# After
format_assistant=StringFormatter(slots=["{{content}}"])
```

With `efficient_eos=True`, the model naturally generates `<|return|>` as the EOS token.

## Verification

After fix, trained models generate the correct token sequence:
```
...assistant<|channel|>final<|message|>content<|return|>
```

This matches the official GPT-OSS format and is compatible with openai_harmony's parser.

## References

- Official format: https://github.com/openai/harmony/raw/main/docs/header.png
- openai_harmony package: StreamableParser

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?
