### PR TITLE
fix(MiniCPMVPlugin): fix IndexError in process_messages when training with video

### DIFF
--- a/src/llamafactory/data/mm_plugin.py
+++ b/src/llamafactory/data/mm_plugin.py
@@ -1058,7 +1058,9 @@ class MiniCPMVPlugin(BasePlugin):
                 chunk_input=True,
                 sampling_rate=getattr(processor, "audio_sampling_rate", 16000),
             )
-            audio_feature_lens = [torch.tensor(audio_feature_len) for audio_feature_len in audio_feature_lens]
+            audio_feature_lens = [
+                x.clone().detach() if isinstance(x, torch.Tensor) else torch.tensor(x) for x in audio_feature_lens
+            ]
             mm_inputs.update({"audio_features": audio_features, "audio_feature_lens": audio_feature_lens})
             if kwargs.get("ret_phs", False):
                 mm_inputs.update({"audio_phs": audio_phs})
@@ -1098,7 +1100,7 @@ class MiniCPMVPlugin(BasePlugin):
                 num_image_tokens += 1
 
             while VIDEO_PLACEHOLDER in content:
-                video_seqlen = len(mm_inputs["pixel_values"][num_video_tokens]) if self.expand_mm_tokens else 1
+                video_seqlen = len(mm_inputs["image_sizes"][num_video_tokens]) if self.expand_mm_tokens else 1
                 content = content.replace(VIDEO_PLACEHOLDER, "{{image}}" * video_seqlen, 1)
                 num_video_tokens += 1
 


### PR DESCRIPTION
## Bug Description

When running SFT on **MiniCPM-o / MiniCPM-V** models (e.g. `MiniCPM-o-4_5`) with **video** data and `expand_mm_tokens` enabled, the dataset tokenization step crashes with:

```
IndexError: list index out of range
  File "src/llamafactory/data/mm_plugin.py", line 1133, in process_messages
    image_sizes[0][idx], idx, max_slice_nums, use_image_id
    ~~~~~~~~~~~~~~^^^^^
```

## Root Cause

In `MiniCPMVPlugin.process_messages()`, two steps are misaligned:

1. **Placeholder insertion (line ~1101):** Each `VIDEO_PLACEHOLDER` is replaced by `N` copies of the image placeholder `(<image>./</image>)`, where `N = len(mm_inputs["pixel_values"][num_video_tokens])`.

2. **Placeholder expansion (line ~1133):** The code iterates over all inserted image placeholders and calls `image_processor.get_slice_image_placeholder(image_sizes[0][idx], ...)`, incrementing `idx` for each one.

The problem is that for MiniCPM-o/V video inputs, `pixel_values` and `image_sizes` have **different lengths per video** — `pixel_values[i]` contains the actual pixel tensors per slice (which can include padding slices), while `image_sizes[i]` contains only the size metadata entries. Using `pixel_values` to determine the placeholder count produces more placeholders than `image_sizes` has entries, so `idx` overflows `image_sizes[0]`.

## Fix

**1. Use `image_sizes` instead of `pixel_values` for video placeholder count (line ~1101):**

```python
# Before (bug):
video_seqlen = len(mm_inputs["pixel_values"][num_video_tokens]) if self.expand_mm_tokens else 1

# After (fix):
video_seqlen = len(mm_inputs["image_sizes"][num_video_tokens]) if self.expand_mm_tokens else 1
```

This ensures the number of inserted image placeholders matches the number of `image_sizes` entries, keeping the subsequent `image_sizes[0][idx]` indexing in bounds.

**2. Avoid `torch.tensor()` on existing tensors in `_get_mm_inputs()` (line ~1061):**

```python
# Before (triggers UserWarning):
audio_feature_lens = [torch.tensor(x) for x in audio_feature_lens]

# After:
audio_feature_lens = [
    x.clone().detach() if isinstance(x, torch.Tensor) else torch.tensor(x)
    for x in audio_feature_lens
]
```

This silences the `UserWarning: To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach()` that occurs when `audio_feature_lens` elements are already tensors.

## Testing

Verified that SFT dataset tokenization completes successfully for MiniCPM-o-4_5 with a video dataset (1433 samples) and `expand_mm_tokens` enabled, which previously crashed at the map step.

## Checklist

- [x] Only `src/llamafactory/data/mm_plugin.py` is modified
- [x] Bug fix only — no behavioral change when counts already match
- [x] Backward compatible

Made with [Cursor](https://cursor.com)