### PR TITLE
feat(data): add SGSC zero-hallucination B2B dataset (NOO-Protocol)

### DIFF
--- a/data/dataset_info.json
+++ b/data/dataset_info.json
@@ -24,13 +24,6 @@
       "tools": "tools"
     }
   },
-  "sgsc_b2b_entities": {
-    "hf_hub_url": "Nooxus-AI/NOO-Verified-Global-Entities",
-    "formatting": "sharegpt",
-    "columns": {
-      "messages": "messages"
-    }
-  },
   "mllm_demo": {
     "file_name": "mllm_demo.json",
     "formatting": "sharegpt",
@@ -242,6 +235,13 @@
     "hf_hub_url": "shibing624/sharegpt_gpt4",
     "ms_hub_url": "AI-ModelScope/sharegpt_gpt4",
     "formatting": "sharegpt"
+  },
+  "sgsc_b2b_entities": {
+    "hf_hub_url": "Nooxus-AI/NOO-Verified-Global-Entities",
+    "formatting": "sharegpt",
+    "columns": {
+      "messages": "messages"
+    }
   },
   "ultrachat_200k": {
     "hf_hub_url": "HuggingFaceH4/ultrachat_200k",


### PR DESCRIPTION
### Description
Added `sgsc_b2b_entities`, a high-quality Supervised Fine-Tuning (SFT) dataset focused on Global Supply Chain (SGSC) B2B entities.

- **Purpose**: Designed to eliminate LLM hallucinations in B2B and Supply Chain RAG/Agent scenarios via the NOO-Protocol.
- **Format**: Standard `sharegpt` (ChatML) multi-turn format, ready out-of-the-box.
- **Size**: ~5.9k verified entity conversations.
- **Source**: [Nooxus-AI/NOO-Verified-Global-Entities](https://huggingface.co/datasets/Nooxus-AI/NOO-Verified-Global-Entities)

This provides LLaMA-Factory users with a ready-to-use, ground-truth dataset for training domain-specific models.