### PR TITLE
fix: handle empty content list in system message

### DIFF
--- a/src/llamafactory/api/chat.py
+++ b/src/llamafactory/api/chat.py
@@ -88,7 +88,10 @@ def _process_request(
 
     if request.messages[0].role == Role.SYSTEM:
         content = request.messages.pop(0).content
-        system = content[0].text if isinstance(content, list) else content
+        if isinstance(content, list):
+            system = content[0].text if content else ""
+        else:
+            system = content
     else:
         system = None
 


### PR DESCRIPTION
## Description
When the system message content is an empty list, accessing `content[0]` would raise an `IndexError`. This fix adds a check for empty list and returns an empty string instead.

## Fix Details
- File: `src/llamafactory/api/chat.py`
- Added validation to check if content list is empty before accessing `content[0]`
- Returns empty string when content is an empty list

## Bug Scenario
This fix addresses a potential crash in the API when processing chat requests with empty system message content.

## Testing
The fix has been verified with the following test cases:
- Empty list content: Returns empty string (PASS)
- String content: Returns content as-is (PASS)
- List with content: Returns first item.text (PASS)