### PR TITLE
fix: LoRA training with Qwen3-VL on multi-GPU

### DIFF
--- a/src/llamafactory/model/model_utils/visual.py
+++ b/src/llamafactory/model/model_utils/visual.py
@@ -367,7 +367,7 @@ _register_composite_model(
     projector_key="visual.merger",
     vision_model_keys=["visual.pos_embed", "visual.patch_embed", "visual.blocks", "visual.deepstack_merger_list"],
     language_model_keys=["language_model", "lm_head"],
-    lora_conflict_keys=["patch_embed"],
+    lora_conflict_keys=["pos_embed", "patch_embed"],
 )
 
 
@@ -376,7 +376,7 @@ _register_composite_model(
     projector_key="visual.merger",
     vision_model_keys=["visual.pos_embed", "visual.patch_embed", "visual.blocks", "visual.deepstack_merger_list"],
     language_model_keys=["language_model", "lm_head"],
-    lora_conflict_keys=["patch_embed"],
+    lora_conflict_keys=["pos_embed", "patch_embed"],
 )
 
 
@@ -391,7 +391,7 @@ _register_composite_model(
         "audio_tower",
     ],
     language_model_keys=["language_model", "lm_head"],
-    lora_conflict_keys=["patch_embed"],
+    lora_conflict_keys=["pos_embed", "patch_embed"],
 )
 
 
@@ -400,7 +400,7 @@ _register_composite_model(
     projector_key="model.visual.merger",
     vision_model_keys=["visual.pos_embed", "visual.patch_embed", "visual.blocks"],
     language_model_keys=["language_model", "lm_head"],
-    lora_conflict_keys=["patch_embed"],
+    lora_conflict_keys=["pos_embed", "patch_embed"],
 )
 
 
@@ -409,7 +409,7 @@ _register_composite_model(
     projector_key="model.visual.merger",
     vision_model_keys=["visual.pos_embed", "visual.patch_embed", "visual.blocks"],
     language_model_keys=["language_model", "lm_head"],
-    lora_conflict_keys=["patch_embed"],
+    lora_conflict_keys=["pos_embed", "patch_embed"],
 )
 
 


### PR DESCRIPTION
Fixes #10295

## Problem
LoRA training with Qwen3-VL models fails on multi-GPU setups due to incorrect handling of the "visual.pos_embed" module.

## Root Cause
When "visual.pos_embed" was added to "vision_model_keys" in commit 9640f79, it was not also added to "lora_conflict_keys". This causes LoRA to potentially target position embedding layers, which leads to DDP errors about unused parameters during multi-GPU training.

## Fix
Add "pos_embed" to "lora_conflict_keys" for all Qwen3-VL model variants:
- qwen3_vl
- qwen3_vl_moe
- qwen3_omni_moe_thinker
- qwen3_5
- qwen3_5_moe

This ensures that position embedding layers are properly excluded from LoRA targeting, matching the behavior of "patch_embed".

## Changes
- Modified: src/llamafactory/model/model_utils/visual.py