### PR TITLE
fix: add qwen3_5_moe to MoE configuration in moe.py

### DIFF
--- a/src/llamafactory/model/model_utils/moe.py
+++ b/src/llamafactory/model/model_utils/moe.py
@@ -179,6 +179,7 @@ def configure_moe(config: "PretrainedConfig", model_args: "ModelArguments", is_t
     if text_config and getattr(text_config, "model_type", None) in [
         "glm4v_moe_text",  # glmv4_5
         "qwen3_moe",  # internvl_3_5
+        "qwen3_5_moe_text",
     ]:
         setattr(text_config, "output_router_logits", True)
 


### PR DESCRIPTION
Fixes #10302

## Changes

Add `qwen3_5_moe` support to `moe.py`:

1. **`add_z3_leaf_module()`**: Add block for `model_type == "qwen3_5_moe"` importing `Qwen3_5MoeSparseMoeBlock`.

2. **`configure_moe()`**: Add `"qwen3_5_moe_text"` to the `output_router_logits` text_config list (alongside `glm4v_moe_text` and `qwen3_moe`).

3. **`configure_moe()`**: Add `"qwen3_5_moe_text"` to the `router_aux_loss_coef` text_config list (alongside `qwen3_moe`). This is the core fix — without this, the `moe_aux_loss_coef` parser argument is silently ignored for qwen3_5_moe models.

`qwen3_5_moe` is a multimodal model where MoE settings belong in `text_config` (text_config.model_type = `qwen3_5_moe_text`), following the same pattern as `glm4v_moe` and `qwen3_moe` (internvl_3_5).