### PR TITLE
[liger_kernel] support Qwen3.5.

### DIFF
--- a/src/llamafactory/model/model_utils/liger_kernel.py
+++ b/src/llamafactory/model/model_utils/liger_kernel.py
@@ -79,6 +79,8 @@ def apply_liger_kernel(
         from liger_kernel.transformers import apply_liger_kernel_to_qwen3_moe as apply_liger_kernel
     elif model_type == "qwen3_next":
         from liger_kernel.transformers import apply_liger_kernel_to_qwen3_next as apply_liger_kernel
+    elif model_type == "qwen3_5":
+        from liger_kernel.transformers import apply_liger_kernel_to_qwen3_5 as apply_liger_kernel
     elif model_type == "gpt_oss":
         try:
             from liger_kernel.transformers import apply_liger_kernel_to_gpt_oss as apply_liger_kernel


### PR DESCRIPTION
# What does this PR do?

Partially fixes #10253. The support of Qwen3.5 dense has been merged into liger-kernel (https://github.com/linkedin/Liger-Kernel/pull/1150).

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?