### PR TITLE
fix: flatten nested input_ids for VL models in save_predictions

### DIFF
--- a/src/llamafactory/train/sft/trainer.py
+++ b/src/llamafactory/train/sft/trainer.py
@@ -220,8 +220,14 @@ class CustomSeq2SeqTrainer(Seq2SeqTrainer):
             input_ids_list = input_ids_column.to_pylist()
         except AttributeError:
             input_ids_list = list(input_ids_column)
+        flat_input_ids = []
+        for ids in input_ids_list:
+            if ids and isinstance(ids[0], list):
+                flat_input_ids.append([tok for sublist in ids for tok in sublist])
+            else:
+                flat_input_ids.append(ids)
 
-        decoded_inputs = self.processing_class.batch_decode(input_ids_list, skip_special_tokens=False)
+        decoded_inputs = self.processing_class.batch_decode(flat_input_ids, skip_special_tokens=False)
         decoded_preds = self.processing_class.batch_decode(preds, skip_special_tokens=skip_special_tokens)
         decoded_labels = self.processing_class.batch_decode(labels, skip_special_tokens=skip_special_tokens)
 

--- a/src/llamafactory/train/sft/trainer.py
+++ b/src/llamafactory/train/sft/trainer.py
@@ -222,7 +222,7 @@ class CustomSeq2SeqTrainer(Seq2SeqTrainer):
             input_ids_list = list(input_ids_column)
         flat_input_ids = []
         for ids in input_ids_list:
-            if ids and isinstance(ids[0], list):
+            if len(ids) > 0 and isinstance(ids[0], (list, tuple)):
                 flat_input_ids.append([tok for sublist in ids for tok in sublist])
             else:
                 flat_input_ids.append(ids)


### PR DESCRIPTION
Fixes #10239

# What does this PR do?
When running NLG evaluation with VL models like Qwen3-VL-4B, 
`save_predictions` crashes with:

TypeError: argument 'ids': 'list' object cannot be interpreted as an integer

VL models store `input_ids` as nested `List[List[int]]` instead of 
flat `List[int]`. Added a flattening step after `.to_pylist()` that 
detects nested lists and flattens them before passing to `batch_decode`. 
Standard text models are unaffected.

## Before submitting
- [x] Did you read the contributor guideline?
- [ ] Did you write any new necessary tests?Fixes #10239

# What does this PR do?
When running NLG evaluation with VL models like Qwen3-VL-4B, 
`save_predictions` crashes with:

TypeError: argument 'ids': 'list' object cannot be interpreted as an integer

VL models store `input_ids` as nested `List[List[int]]` instead of 
flat `List[int]`. Added a flattening step after `.to_pylist()` that 
detects nested lists and flattens them before passing to `batch_decode`. 
Standard text models are unaffected.

## Before submitting
- [x] Did you read the contributor guideline?
- [ ] Did you write any new necessary tests?