### PR TITLE
Enhance get_projectors method with missing key checks

### DIFF
--- a/src/llamafactory/model/model_utils/visual.py
+++ b/src/llamafactory/model/model_utils/visual.py
@@ -49,21 +49,15 @@ class CompositeModel:
         mm_projectors: list[torch.nn.Module] = []
         for projector_key in self.projector_keys:
             mm_projector = module
-            missing_key = False
             for key in projector_key.split("."):
-                if not hasattr(mm_projector, key):
-                    missing_key = True
+                mm_projector = getattr(mm_projector, key, None)
+                if mm_projector is None:
                     logger.warning_rank0(
-                        f"Skip missing multimodal projector `{projector_key}` for model type `{self.model_type}`."
+                        f"Skip missing multimodal projector {projector_key} for model type {self.model_type}."
                     )
                     break
-
-                mm_projector = getattr(mm_projector, key)
-
-            if missing_key:
-                continue
-
-            mm_projectors.append(mm_projector)
+            else:
+                mm_projectors.append(mm_projector)
 
         return mm_projectors
 

--- a/src/llamafactory/model/model_utils/visual.py
+++ b/src/llamafactory/model/model_utils/visual.py
@@ -49,8 +49,19 @@ class CompositeModel:
         mm_projectors: list[torch.nn.Module] = []
         for projector_key in self.projector_keys:
             mm_projector = module
+            missing_key = False
             for key in projector_key.split("."):
+                if not hasattr(mm_projector, key):
+                    missing_key = True
+                    logger.warning_rank0(
+                        f"Skip missing multimodal projector `{projector_key}` for model type `{self.model_type}`."
+                    )
+                    break
+
                 mm_projector = getattr(mm_projector, key)
+
+            if missing_key:
+                continue
 
             mm_projectors.append(mm_projector)
 
@@ -144,6 +155,12 @@ def autocast_projector_dtype(model: "PreTrainedModel", model_args: "ModelArgumen
         if model_type in COMPOSITE_MODELS:
             mm_projectors = COMPOSITE_MODELS[model_type].get_projectors(model)
         else:
+            return
+
+        if not mm_projectors:
+            logger.warning_rank0(
+                f"No multimodal projector found for model type `{model_type}`, skip projector dtype autocast."
+            )
             return
 
         logger.info_rank0(


### PR DESCRIPTION
Added a check for missing projector keys and updated logging for clarity.

# What does this PR do?

Fixes https://github.com/hiyouga/LlamaFactory/issues/10376

在使用https://github.com/hiyouga/LlamaFactory/pull/10378 后再次执行，但还是报错
```
AttributeError: 'Gemma4ForConditionalGeneration' object has no attribute 'embed_vision'
```
因此添加 不存在 embed_vision 或 embed_audio 会跳过这些 projector

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?
