### PR TITLE
fix: bump transformers upper bound to 5.5.4 for Gemma4 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "torch>=2.4.0",
     "torchvision>=0.19.0",
     "torchaudio>=2.4.0",
-    "transformers>=4.55.0,<=5.2.0,!=4.52.0,!=4.57.0",
+    "transformers>=4.55.0,<=5.5.4,!=4.52.0,!=4.57.0",
     "datasets>=2.16.0,<=4.0.0",
     "accelerate>=1.3.0,<=1.11.0",
     "peft>=0.18.0,<=0.18.1",

--- a/src/llamafactory/extras/misc.py
+++ b/src/llamafactory/extras/misc.py
@@ -94,7 +94,7 @@ def check_version(requirement: str, mandatory: bool = False) -> None:
 
 def check_dependencies() -> None:
     r"""Check the version of the required packages."""
-    check_version("transformers>=4.55.0,<=5.2.0")
+    check_version("transformers>=4.55.0,<=5.5.4")
     check_version("datasets>=2.16.0,<=4.0.0")
     check_version("accelerate>=1.3.0,<=1.11.0")
     check_version("peft>=0.18.0,<=0.18.1")


### PR DESCRIPTION
## Problem

Gemma4 requires `transformers>=5.5.0`, but LLaMA-Factory's current version constraint is `transformers>=4.55.0,<=5.2.0`. This causes an `ImportError` at startup:

```
ImportError: transformers>=4.55.0,<=5.2.0 is required for a normal functioning of this module,
but found transformers==5.5.0.
To fix: run `pip install transformers>=4.55.0,<=5.2.0` or set `DISABLE_VERSION_CHECK=1` to skip this check.
```

Fixes #10389.

## Changes

- `pyproject.toml`: update `transformers` upper bound from `5.2.0` to `5.5.4` (current PyPI latest)
- `src/llamafactory/extras/misc.py`: update `check_version` call to match

## Notes

- `transformers 5.5.4` is the latest stable release as of 2026-04-14
- No breaking API changes for LLaMA-Factory's usage were identified between 5.2.0 and 5.5.4
- The existing exclusions (`!=4.52.0,!=4.57.0`) are preserved